### PR TITLE
BREAKING CHANGE: Initial state can now be passed to Persistence

### DIFF
--- a/test/managed/shared_doc_supervisor_test.exs
+++ b/test/managed/shared_doc_supervisor_test.exs
@@ -10,7 +10,27 @@ defmodule Yex.Managed.SharedDocSupervisorTest do
   end
 
   defp random_docname() do
-    :crypto.strong_rand_bytes(10)
+    for _ <- 1..10,
+        into: "",
+        do:
+          Enum.random([
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f"
+          ])
   end
 
   defp receive_and_handle_reply_with_timeout(doc, timeout \\ 10) do
@@ -82,5 +102,55 @@ defmodule Yex.Managed.SharedDocSupervisorTest do
 
     Task.await(client1)
     Task.await(client2)
+  end
+
+  describe "override option" do
+    defmodule TestPersistence do
+      @behaviour Yex.Managed.SharedDoc.PersistenceBehaviour
+
+      def bind(state, _doc_name, doc) do
+        Doc.get_array(doc, "array")
+        |> Array.insert(0, "initial_data")
+
+        state
+      end
+
+      def unbind(state, doc_name, doc) do
+        case Yex.encode_state_as_update(doc) do
+          {:ok, update} ->
+            File.write!(Path.join(state.out_dir, doc_name), update, [:write, :binary])
+
+          _ ->
+            []
+        end
+
+        :ok
+      end
+
+      def update_v1(state, _update, _doc_name, _doc) do
+        state
+      end
+    end
+
+    @tag :tmp_dir
+    test "persistence and arg", %{tmp_dir: tmp_dir} do
+      docname = random_docname()
+
+      {:ok, remote_shared_doc} =
+        SharedDocSupervisor.start_child(docname,
+          persistence: {TestPersistence, %{out_dir: tmp_dir}},
+          idle_timeout: 1
+        )
+
+      remote_shared_doc = GenServer.whereis(remote_shared_doc)
+      Process.monitor(remote_shared_doc)
+
+      assert_receive {:DOWN, _, :process, ^remote_shared_doc, _}
+
+      # see TestPersistence.unbind/3
+      persistence_data_path = Path.join(tmp_dir, docname)
+      data = File.read!(persistence_data_path)
+      assert byte_size(data) > 0
+    end
   end
 end

--- a/test/managed/shared_doc_test.exs
+++ b/test/managed/shared_doc_test.exs
@@ -159,7 +159,7 @@ defmodule Yex.Managed.SharedDocTest do
       defmodule PersistenceTest do
         @behaviour Yex.Managed.SharedDoc.PersistenceBehaviour
 
-        def bind(_doc_name, doc) do
+        def bind(_arg, _doc_name, doc) do
           Doc.get_array(doc, "array")
           |> Array.insert(0, "initial_data")
 
@@ -203,7 +203,7 @@ defmodule Yex.Managed.SharedDocTest do
       defmodule PersistenceFileWriteTest do
         @behaviour Yex.Managed.SharedDoc.PersistenceBehaviour
 
-        def bind(_doc_name, doc) do
+        def bind(_state, _doc_name, doc) do
           Doc.get_array(doc, "array")
           |> Array.insert(0, "initial_data")
 
@@ -220,10 +220,6 @@ defmodule Yex.Managed.SharedDocTest do
           end
 
           :ok
-        end
-
-        def update_v1(state, update, _doc_name, _doc) do
-          [update | state]
         end
       end
 


### PR DESCRIPTION
init_arg has been added to the beginning of the Persistence.bind argument.