### PR TITLE
 refactor: Rename get to fetch

### DIFF
--- a/lib/shared_type/array.ex
+++ b/lib/shared_type/array.ex
@@ -54,6 +54,12 @@ defmodule Yex.Array do
 
   @doc """
   Get content at the specified index.
+  ## Examples Sync two clients by exchanging the complete document structure
+      iex> doc = Yex.Doc.new()
+      iex> array = Yex.Doc.get_array(doc, "array")
+      iex> Yex.Array.push(array, "Hello")
+      iex> Yex.Array.get(array, 0)
+      {:ok, "Hello"}
   """
   @deprecated "Rename to `fetch/2`"
   @spec get(t, integer()) :: {:ok, term()} | :error
@@ -68,6 +74,14 @@ defmodule Yex.Array do
   def fetch(%__MODULE__{} = array, index) do
     index = if index < 0, do: __MODULE__.length(array) + index, else: index
     Yex.Nif.array_get(array, cur_txn(array), index) |> Yex.Nif.Util.unwrap_tuple()
+  end
+
+  @spec fetch!(t, integer()) :: term()
+  def fetch!(%__MODULE__{} = array, index) do
+    case fetch(array, index) do
+      {:ok, value} -> value
+      :error -> raise ArgumentError, "Index out of bounds"
+    end
   end
 
   @doc """

--- a/lib/shared_type/array.ex
+++ b/lib/shared_type/array.ex
@@ -55,8 +55,17 @@ defmodule Yex.Array do
   @doc """
   Get content at the specified index.
   """
+  @deprecated "Rename to `fetch/2`"
   @spec get(t, integer()) :: {:ok, term()} | :error
-  def get(%__MODULE__{} = array, index) do
+  def get(array, index) do
+    fetch(array, index)
+  end
+
+  @doc """
+  Get content at the specified index.
+  """
+  @spec fetch(t, integer()) :: {:ok, term()} | :error
+  def fetch(%__MODULE__{} = array, index) do
     index = if index < 0, do: __MODULE__.length(array) + index, else: index
     Yex.Nif.array_get(array, cur_txn(array), index) |> Yex.Nif.Util.unwrap_tuple()
   end
@@ -121,8 +130,8 @@ defmodule Yex.ArrayPrelim do
       iex> doc = Yex.Doc.new()
       iex> map = Yex.Doc.get_map(doc, "map")
       iex> Yex.Map.set(map, "key", Yex.ArrayPrelim.from(["Hello", "World"]))
-      iex> {:ok, %Yex.Array{} = array} = Yex.Map.get(map, "key")
-      iex> Yex.Array.get(array, 1)
+      iex> {:ok, %Yex.Array{} = array} = Yex.Map.fetch(map, "key")
+      iex> Yex.Array.fetch(array, 1)
       {:ok, "World"}
 
   """

--- a/lib/shared_type/map.ex
+++ b/lib/shared_type/map.ex
@@ -51,7 +51,7 @@ defmodule Yex.Map do
       :error
   """
   @deprecated "Rename to `fetch/2`"
-  @spec get(t, term()) :: {:ok, term()} | :error
+  @spec get(t, binary()) :: {:ok, term()} | :error
   def get(map, key) do
     fetch(map, key)
   end
@@ -67,9 +67,17 @@ defmodule Yex.Map do
       iex> Yex.Map.fetch(map, "not_found")
       :error
   """
-  @spec fetch(t, term()) :: {:ok, term()} | :error
+  @spec fetch(t, binary()) :: {:ok, term()} | :error
   def fetch(%__MODULE__{} = map, key) do
     Yex.Nif.map_get(map, cur_txn(map), key) |> Yex.Nif.Util.unwrap_tuple()
+  end
+
+  @spec fetch(t, binary()) :: {:ok, term()} | :error
+  def fetch!(%__MODULE__{} = map, key) do
+    case fetch(map, key) do
+      {:ok, value} -> value
+      :error -> raise ArgumentError, "Key not found"
+    end
   end
 
   @doc """

--- a/lib/shared_type/map.ex
+++ b/lib/shared_type/map.ex
@@ -50,8 +50,25 @@ defmodule Yex.Map do
       iex> Yex.Map.get(map, "not_found")
       :error
   """
+  @deprecated "Rename to `fetch/2`"
   @spec get(t, term()) :: {:ok, term()} | :error
-  def get(%__MODULE__{} = map, key) do
+  def get(map, key) do
+    fetch(map, key)
+  end
+
+  @doc """
+  get a key from the map.
+  ## Examples
+      iex> doc = Yex.Doc.new()
+      iex> map = Yex.Doc.get_map(doc, "map")
+      iex> Yex.Map.set(map, "plane", ["Hello", "World"])
+      iex> Yex.Map.fetch(map, "plane")
+      {:ok, ["Hello", "World"]}
+      iex> Yex.Map.fetch(map, "not_found")
+      :error
+  """
+  @spec fetch(t, term()) :: {:ok, term()} | :error
+  def fetch(%__MODULE__{} = map, key) do
     Yex.Nif.map_get(map, cur_txn(map), key) |> Yex.Nif.Util.unwrap_tuple()
   end
 
@@ -103,8 +120,8 @@ defmodule Yex.MapPrelim do
       iex> doc = Yex.Doc.new()
       iex> array = Yex.Doc.get_array(doc, "array")
       iex> Yex.Array.insert(array, 0, Yex.MapPrelim.from(%{ "key" => "value" }))
-      iex> {:ok, %Yex.Map{} = map} = Yex.Array.get(array, 0)
-      iex> Yex.Map.get(map, "key")
+      iex> {:ok, %Yex.Map{} = map} = Yex.Array.fetch(array, 0)
+      iex> Yex.Map.fetch(map, "key")
       {:ok, "value"}
   """
   defstruct [

--- a/lib/shared_type/text.ex
+++ b/lib/shared_type/text.ex
@@ -93,7 +93,7 @@ defmodule Yex.TextPrelim do
       iex> doc = Yex.Doc.new()
       iex> map = Yex.Doc.get_map(doc, "map")
       iex> Yex.Map.set(map, "key", Yex.TextPrelim.from("Hello World"))
-      iex> {:ok, %Yex.Text{} = text} = Yex.Map.get(map, "key")
+      iex> {:ok, %Yex.Text{} = text} = Yex.Map.fetch(map, "key")
       iex> Yex.Text.to_delta(text)
       [%{insert: "Hello World"}]
 
@@ -112,7 +112,7 @@ defmodule Yex.TextPrelim do
       iex> doc = Yex.Doc.new()
       iex> map = Yex.Doc.get_map(doc, "map")
       iex> Yex.Map.set(map, "key", Yex.TextPrelim.from("Hello World"))
-      iex> {:ok, %Yex.Text{} = text} = Yex.Map.get(map, "key")
+      iex> {:ok, %Yex.Text{} = text} = Yex.Map.fetch(map, "key")
       iex> Yex.Text.to_delta(text)
       [%{insert: "Hello World"}]
 
@@ -121,7 +121,7 @@ defmodule Yex.TextPrelim do
       iex> doc = Yex.Doc.new()
       iex> map = Yex.Doc.get_map(doc, "map")
       iex> Yex.Map.set(map, "key", Yex.TextPrelim.from([%{insert: "Hello"},%{insert: " World", attributes: %{ "bold" => true }},]))
-      iex> {:ok, %Yex.Text{} = text} = Yex.Map.get(map, "key")
+      iex> {:ok, %Yex.Text{} = text} = Yex.Map.fetch(map, "key")
       iex> Yex.Text.to_delta(text)
       [%{insert: "Hello"}, %{attributes: %{"bold" => true}, insert: " World"}]
   """

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -61,6 +61,14 @@ defmodule Yex.XmlElement do
     |> Yex.Nif.Util.unwrap_tuple()
   end
 
+  @spec fetch(t, integer()) :: Yex.XmlElement.t() | Yex.XmlText.t()
+  def fetch!(%__MODULE__{} = map, index) do
+    case fetch(map, index) do
+      {:ok, value} -> value
+      :error -> raise ArgumentError, "Index out of bounds"
+    end
+  end
+
   @spec insert_attribute(t, binary(), binary()) :: :ok | :error
   def insert_attribute(%__MODULE__{} = xml_element, key, value) do
     Yex.Nif.xml_element_insert_attribute(xml_element, cur_txn(xml_element), key, value)

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -49,8 +49,14 @@ defmodule Yex.XmlElement do
     insert(xml_element, 0, content)
   end
 
+  @deprecated "Rename to `fetch/2`"
   @spec get(t, integer()) :: {:ok, Yex.XmlElement.t() | Yex.XmlText.t()} | :error
   def get(%__MODULE__{} = xml_element, index) do
+    fetch(xml_element, index)
+  end
+
+  @spec fetch(t, integer()) :: {:ok, Yex.XmlElement.t() | Yex.XmlText.t()} | :error
+  def fetch(%__MODULE__{} = xml_element, index) do
     Yex.Nif.xml_element_get(xml_element, cur_txn(xml_element), index)
     |> Yex.Nif.Util.unwrap_tuple()
   end

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -61,22 +61,22 @@ defmodule Yex.XmlElement do
     |> Yex.Nif.Util.unwrap_tuple()
   end
 
-  @spec insert_attribute(t, term(), term()) :: :ok | :error
+  @spec insert_attribute(t, binary(), binary()) :: :ok | :error
   def insert_attribute(%__MODULE__{} = xml_element, key, value) do
     Yex.Nif.xml_element_insert_attribute(xml_element, cur_txn(xml_element), key, value)
   end
 
-  @spec remove_attribute(t, term()) :: :ok | :error
+  @spec remove_attribute(t, binary()) :: :ok | :error
   def remove_attribute(%__MODULE__{} = xml_element, key) do
     Yex.Nif.xml_element_remove_attribute(xml_element, cur_txn(xml_element), key)
   end
 
-  @spec get_attribute(t, term()) :: term() | :error
+  @spec get_attribute(t, binary()) :: binary() | nil
   def get_attribute(%__MODULE__{} = xml_element, key) do
     Yex.Nif.xml_element_get_attribute(xml_element, cur_txn(xml_element), key)
   end
 
-  @spec get_attributes(t) :: map() | :error
+  @spec get_attributes(t) :: map()
   def get_attributes(%__MODULE__{} = xml_element) do
     Yex.Nif.xml_element_get_attributes(xml_element, cur_txn(xml_element))
   end

--- a/lib/shared_type/xml_fragment.ex
+++ b/lib/shared_type/xml_fragment.ex
@@ -43,8 +43,14 @@ defmodule Yex.XmlFragment do
     insert(xml_fragment, 0, content)
   end
 
+  @deprecated "Rename to `fetch/2`"
   @spec get(t, integer()) :: {:ok, Yex.XmlElement.t() | Yex.XmlText.t()} | :error
   def get(%__MODULE__{} = xml_fragment, index) do
+    fetch(xml_fragment, index)
+  end
+
+  @spec fetch(t, integer()) :: {:ok, Yex.XmlElement.t() | Yex.XmlText.t()} | :error
+  def fetch(%__MODULE__{} = xml_fragment, index) do
     Yex.Nif.xml_fragment_get(xml_fragment, cur_txn(xml_fragment), index)
     |> Yex.Nif.Util.unwrap_tuple()
   end

--- a/lib/shared_type/xml_fragment.ex
+++ b/lib/shared_type/xml_fragment.ex
@@ -55,6 +55,14 @@ defmodule Yex.XmlFragment do
     |> Yex.Nif.Util.unwrap_tuple()
   end
 
+  @spec fetch(t, integer()) :: Yex.XmlElement.t() | Yex.XmlText.t()
+  def fetch!(%__MODULE__{} = map, index) do
+    case fetch(map, index) do
+      {:ok, value} -> value
+      :error -> raise ArgumentError, "Index out of bounds"
+    end
+  end
+
   @spec to_string(t) :: binary()
   def to_string(%__MODULE__{} = xml_fragment) do
     Yex.Nif.xml_fragment_to_string(xml_fragment, cur_txn(xml_fragment))

--- a/lib/shared_type/xml_text.ex
+++ b/lib/shared_type/xml_text.ex
@@ -79,7 +79,7 @@ defmodule Yex.XmlTextPrelim do
       iex> doc = Yex.Doc.new()
       iex> xml = Yex.Doc.get_xml_fragment(doc, "xml")
       iex> Yex.XmlFragment.insert(xml, 0,  Yex.XmlTextPrelim.from("Hello World"))
-      iex> {:ok, %Yex.XmlText{} = text} = Yex.XmlFragment.get(xml, 0)
+      iex> {:ok, %Yex.XmlText{} = text} = Yex.XmlFragment.fetch(xml, 0)
       iex> Yex.XmlText.to_delta(text)
       [%{insert: "Hello World"}]
 
@@ -100,7 +100,7 @@ defmodule Yex.XmlTextPrelim do
       iex> doc = Yex.Doc.new()
       iex> map = Yex.Doc.get_map(doc, "map")
       iex> Yex.Map.set(map, "key", Yex.XmlTextPrelim.from("Hello World"))
-      iex> {:ok, %Yex.XmlText{} = text} = Yex.Map.get(map, "key")
+      iex> {:ok, %Yex.XmlText{} = text} = Yex.Map.fetch(map, "key")
       iex> Yex.XmlText.to_delta(text)
       [%{insert: "Hello World"}]
 
@@ -109,7 +109,7 @@ defmodule Yex.XmlTextPrelim do
       iex> doc = Yex.Doc.new()
       iex> map = Yex.Doc.get_map(doc, "map")
       iex> Yex.Map.set(map, "key", Yex.XmlTextPrelim.from([%{insert: "Hello"},%{insert: " World", attributes: %{ "bold" => true }},]))
-      iex> {:ok,%Yex.XmlText{} = text} = Yex.Map.get(map, "key")
+      iex> {:ok,%Yex.XmlText{} = text} = Yex.Map.fetch(map, "key")
       iex> Yex.XmlText.to_delta(text)
       [%{insert: "Hello"}, %{attributes: %{"bold" => true}, insert: " World"}]
   """

--- a/test/shared_type/array_test.exs
+++ b/test/shared_type/array_test.exs
@@ -24,17 +24,17 @@ defmodule Yex.ArrayTest do
     assert 2 == Array.length(array)
   end
 
-  test "get" do
+  test "fetch" do
     doc = Doc.new()
 
     array = Doc.get_array(doc, "array")
 
     Array.push(array, "Hello1")
     Array.push(array, "Hello2")
-    assert {:ok, "Hello1"} == Array.get(array, 0)
-    assert {:ok, "Hello2"} == Array.get(array, 1)
-    assert :error == Array.get(array, 2)
-    assert {:ok, "Hello2"} == Array.get(array, -1)
+    assert {:ok, "Hello1"} == Array.fetch(array, 0)
+    assert {:ok, "Hello2"} == Array.fetch(array, 1)
+    assert :error == Array.fetch(array, 2)
+    assert {:ok, "Hello2"} == Array.fetch(array, -1)
   end
 
   test "unshift" do

--- a/test/shared_type/array_test.exs
+++ b/test/shared_type/array_test.exs
@@ -36,6 +36,20 @@ defmodule Yex.ArrayTest do
     assert :error == Array.fetch(array, 2)
     assert {:ok, "Hello2"} == Array.fetch(array, -1)
   end
+  test "fetch!" do
+    doc = Doc.new()
+
+    array = Doc.get_array(doc, "array")
+
+    Array.push(array, "Hello1")
+    Array.push(array, "Hello2")
+    assert  "Hello1" == Array.fetch!(array, 0)
+    assert  "Hello2" == Array.fetch!(array, 1)
+    assert_raise ArgumentError, "Index out of bounds", fn ->
+      Array.fetch!(array, 2)
+    end
+    assert  "Hello2" == Array.fetch!(array, -1)
+  end
 
   test "unshift" do
     doc = Doc.new()

--- a/test/shared_type/array_test.exs
+++ b/test/shared_type/array_test.exs
@@ -36,6 +36,7 @@ defmodule Yex.ArrayTest do
     assert :error == Array.fetch(array, 2)
     assert {:ok, "Hello2"} == Array.fetch(array, -1)
   end
+
   test "fetch!" do
     doc = Doc.new()
 
@@ -43,12 +44,14 @@ defmodule Yex.ArrayTest do
 
     Array.push(array, "Hello1")
     Array.push(array, "Hello2")
-    assert  "Hello1" == Array.fetch!(array, 0)
-    assert  "Hello2" == Array.fetch!(array, 1)
+    assert "Hello1" == Array.fetch!(array, 0)
+    assert "Hello2" == Array.fetch!(array, 1)
+
     assert_raise ArgumentError, "Index out of bounds", fn ->
       Array.fetch!(array, 2)
     end
-    assert  "Hello2" == Array.fetch!(array, -1)
+
+    assert "Hello2" == Array.fetch!(array, -1)
   end
 
   test "unshift" do

--- a/test/shared_type/map_test.exs
+++ b/test/shared_type/map_test.exs
@@ -32,8 +32,9 @@ defmodule Yex.MapTest do
 
     Map.set(map, "key", "Hello1")
     Map.set(map, "key2", "Hello2")
-    assert  "Hello1" == Map.fetch!(map, "key")
+    assert "Hello1" == Map.fetch!(map, "key")
     assert "Hello2" == Map.fetch!(map, "key2")
+
     assert_raise ArgumentError, "Key not found", fn ->
       Map.fetch!(map, "key3")
     end

--- a/test/shared_type/map_test.exs
+++ b/test/shared_type/map_test.exs
@@ -20,8 +20,8 @@ defmodule Yex.MapTest do
 
     Map.set(map, "key", "Hello1")
     Map.set(map, "key2", "Hello2")
-    assert {:ok, "Hello1"} == Map.get(map, "key")
-    assert {:ok, "Hello2"} == Map.get(map, "key2")
+    assert {:ok, "Hello1"} == Map.fetch(map, "key")
+    assert {:ok, "Hello2"} == Map.fetch(map, "key2")
   end
 
   test "delete" do
@@ -32,8 +32,8 @@ defmodule Yex.MapTest do
     Map.set(map, "key", "Hello1")
     Map.set(map, "key2", "Hello2")
     Map.delete(map, "key2")
-    assert {:ok, "Hello1"} == Map.get(map, "key")
-    assert :error == Map.get(map, "key2")
+    assert {:ok, "Hello1"} == Map.fetch(map, "key")
+    assert :error == Map.fetch(map, "key2")
   end
 
   test "MapPrelim" do
@@ -42,7 +42,7 @@ defmodule Yex.MapTest do
     map = Doc.get_map(doc, "map")
 
     Map.set(map, "key", MapPrelim.from(%{"key" => "Hello"}))
-    assert {:ok, inner_map} = Map.get(map, "key")
+    assert {:ok, inner_map} = Map.fetch(map, "key")
     assert %{"key" => "Hello"} == Map.to_map(inner_map)
 
     assert 1 == Map.size(map)

--- a/test/shared_type/map_test.exs
+++ b/test/shared_type/map_test.exs
@@ -13,7 +13,7 @@ defmodule Yex.MapTest do
     assert 1 == Map.size(map)
   end
 
-  test "get" do
+  test "fetch" do
     doc = Doc.new()
 
     map = Doc.get_map(doc, "map")
@@ -22,6 +22,21 @@ defmodule Yex.MapTest do
     Map.set(map, "key2", "Hello2")
     assert {:ok, "Hello1"} == Map.fetch(map, "key")
     assert {:ok, "Hello2"} == Map.fetch(map, "key2")
+    assert :error == Map.fetch(map, "key3")
+  end
+
+  test "fetch!" do
+    doc = Doc.new()
+
+    map = Doc.get_map(doc, "map")
+
+    Map.set(map, "key", "Hello1")
+    Map.set(map, "key2", "Hello2")
+    assert  "Hello1" == Map.fetch!(map, "key")
+    assert "Hello2" == Map.fetch!(map, "key2")
+    assert_raise ArgumentError, "Key not found", fn ->
+      Map.fetch!(map, "key3")
+    end
   end
 
   test "delete" do

--- a/test/shared_type/xml_element_test.exs
+++ b/test/shared_type/xml_element_test.exs
@@ -9,7 +9,7 @@ defmodule YexXmlElementTest do
       d1 = Doc.with_options(%Doc.Options{client_id: 1})
       f = Doc.get_xml_fragment(d1, "xml")
       XmlFragment.push(f, XmlElementPrelim.empty("div"))
-      {:ok, xml} = XmlFragment.get(f, 0)
+      {:ok, xml} = XmlFragment.fetch(f, 0)
       %{doc: d1, xml_element: xml, xml_fragment: f}
     end
 
@@ -23,7 +23,7 @@ defmodule YexXmlElementTest do
 
       XmlFragment.push(f, XmlElementPrelim.empty("div"))
 
-      {:ok, xml2} = XmlFragment.get(f, 0)
+      {:ok, xml2} = XmlFragment.fetch(f, 0)
 
       {:ok, u} = Yex.encode_state_as_update(d1)
       Yex.apply_update(d2, u)
@@ -33,9 +33,9 @@ defmodule YexXmlElementTest do
 
     test "unshift", %{xml_element: xml} do
       XmlElement.push(xml, XmlTextPrelim.from(""))
-      {:ok, %XmlText{}} = XmlElement.get(xml, 0)
+      {:ok, %XmlText{}} = XmlElement.fetch(xml, 0)
       XmlElement.unshift(xml, XmlElementPrelim.empty("div"))
-      {:ok, %XmlElement{}} = XmlElement.get(xml, 0)
+      {:ok, %XmlElement{}} = XmlElement.fetch(xml, 0)
     end
 
     test "delete", %{xml_element: xml} do

--- a/test/shared_type/xml_element_test.exs
+++ b/test/shared_type/xml_element_test.exs
@@ -13,17 +13,18 @@ defmodule YexXmlElementTest do
       %{doc: d1, xml_element: xml, xml_fragment: f}
     end
 
-    test "fetch", %{xml_element: xml}  do
+    test "fetch", %{xml_element: xml} do
       XmlElement.push(xml, XmlElementPrelim.empty("div"))
 
-      assert {:ok,  %XmlElement{}} = XmlElement.fetch(xml, 0)
+      assert {:ok, %XmlElement{}} = XmlElement.fetch(xml, 0)
       assert :error == XmlElement.fetch(xml, 1)
     end
-    test "fetch!", %{xml_element: xml}  do
 
+    test "fetch!", %{xml_element: xml} do
       XmlElement.push(xml, XmlElementPrelim.empty("div"))
 
-      assert  %XmlElement{} = XmlElement.fetch!(xml, 0)
+      assert %XmlElement{} = XmlElement.fetch!(xml, 0)
+
       assert_raise ArgumentError, "Index out of bounds", fn ->
         XmlElement.fetch!(xml, 1)
       end

--- a/test/shared_type/xml_element_test.exs
+++ b/test/shared_type/xml_element_test.exs
@@ -13,6 +13,22 @@ defmodule YexXmlElementTest do
       %{doc: d1, xml_element: xml, xml_fragment: f}
     end
 
+    test "fetch", %{xml_element: xml}  do
+      XmlElement.push(xml, XmlElementPrelim.empty("div"))
+
+      assert {:ok,  %XmlElement{}} = XmlElement.fetch(xml, 0)
+      assert :error == XmlElement.fetch(xml, 1)
+    end
+    test "fetch!", %{xml_element: xml}  do
+
+      XmlElement.push(xml, XmlElementPrelim.empty("div"))
+
+      assert  %XmlElement{} = XmlElement.fetch!(xml, 0)
+      assert_raise ArgumentError, "Index out of bounds", fn ->
+        XmlElement.fetch!(xml, 1)
+      end
+    end
+
     test "insert_attribute", %{doc: d1, xml_element: xml1} do
       XmlElement.insert_attribute(xml1, "height", "10")
 

--- a/test/shared_type/xml_fragment_test.exs
+++ b/test/shared_type/xml_fragment_test.exs
@@ -12,22 +12,22 @@ defmodule YexXmlFragmentTest do
   describe "xml_fragment" do
     test "push", %{xml_fragment: f} do
       XmlFragment.push(f, XmlTextPrelim.from(""))
-      {:ok, %XmlText{}} = XmlFragment.get(f, 0)
+      {:ok, %XmlText{}} = XmlFragment.fetch(f, 0)
       XmlFragment.push(f, XmlElementPrelim.empty("div"))
-      {:ok, %XmlElement{}} = XmlFragment.get(f, 1)
+      {:ok, %XmlElement{}} = XmlFragment.fetch(f, 1)
     end
 
     test "unshift", %{xml_fragment: f} do
       XmlFragment.push(f, XmlTextPrelim.from(""))
-      {:ok, %XmlText{}} = XmlFragment.get(f, 0)
+      {:ok, %XmlText{}} = XmlFragment.fetch(f, 0)
       XmlFragment.unshift(f, XmlElementPrelim.empty("div"))
-      {:ok, %XmlElement{}} = XmlFragment.get(f, 0)
+      {:ok, %XmlElement{}} = XmlFragment.fetch(f, 0)
     end
 
     test "delete", %{xml_fragment: f} do
       XmlFragment.push(f, XmlTextPrelim.from(""))
       :ok = XmlFragment.delete(f, 0, 1)
-      :error = XmlFragment.get(f, 0)
+      :error = XmlFragment.fetch(f, 0)
     end
 
     test "first_child", %{xml_fragment: f} do
@@ -67,7 +67,7 @@ defmodule YexXmlFragmentTest do
       XmlFragment.push(f, XmlElementPrelim.empty("div"))
       XmlFragment.push(f, XmlElementPrelim.empty("div"))
 
-      {:ok, last} = XmlFragment.get(f, 5)
+      {:ok, last} = XmlFragment.fetch(f, 5)
 
       stream =
         Stream.unfold(last, fn

--- a/test/shared_type/xml_fragment_test.exs
+++ b/test/shared_type/xml_fragment_test.exs
@@ -10,7 +10,6 @@ defmodule YexXmlFragmentTest do
   end
 
   describe "xml_fragment" do
-
     test "push", %{xml_fragment: f} do
       XmlFragment.push(f, XmlTextPrelim.from(""))
       {:ok, %XmlText{}} = XmlFragment.fetch(f, 0)
@@ -25,17 +24,18 @@ defmodule YexXmlFragmentTest do
       {:ok, %XmlElement{}} = XmlFragment.fetch(f, 0)
     end
 
-    test "fetch", %{xml_fragment: xml}  do
+    test "fetch", %{xml_fragment: xml} do
       XmlFragment.push(xml, XmlElementPrelim.empty("div"))
 
-      assert {:ok,  %XmlElement{}} = XmlFragment.fetch(xml, 0)
+      assert {:ok, %XmlElement{}} = XmlFragment.fetch(xml, 0)
       assert :error == XmlFragment.fetch(xml, 1)
     end
-    test "fetch!", %{xml_fragment: xml}  do
 
+    test "fetch!", %{xml_fragment: xml} do
       XmlFragment.push(xml, XmlElementPrelim.empty("div"))
 
-      assert  %XmlElement{} = XmlFragment.fetch!(xml, 0)
+      assert %XmlElement{} = XmlFragment.fetch!(xml, 0)
+
       assert_raise ArgumentError, "Index out of bounds", fn ->
         XmlFragment.fetch!(xml, 1)
       end

--- a/test/shared_type/xml_fragment_test.exs
+++ b/test/shared_type/xml_fragment_test.exs
@@ -10,6 +10,7 @@ defmodule YexXmlFragmentTest do
   end
 
   describe "xml_fragment" do
+
     test "push", %{xml_fragment: f} do
       XmlFragment.push(f, XmlTextPrelim.from(""))
       {:ok, %XmlText{}} = XmlFragment.fetch(f, 0)
@@ -22,6 +23,22 @@ defmodule YexXmlFragmentTest do
       {:ok, %XmlText{}} = XmlFragment.fetch(f, 0)
       XmlFragment.unshift(f, XmlElementPrelim.empty("div"))
       {:ok, %XmlElement{}} = XmlFragment.fetch(f, 0)
+    end
+
+    test "fetch", %{xml_fragment: xml}  do
+      XmlFragment.push(xml, XmlElementPrelim.empty("div"))
+
+      assert {:ok,  %XmlElement{}} = XmlFragment.fetch(xml, 0)
+      assert :error == XmlFragment.fetch(xml, 1)
+    end
+    test "fetch!", %{xml_fragment: xml}  do
+
+      XmlFragment.push(xml, XmlElementPrelim.empty("div"))
+
+      assert  %XmlElement{} = XmlFragment.fetch!(xml, 0)
+      assert_raise ArgumentError, "Index out of bounds", fn ->
+        XmlFragment.fetch!(xml, 1)
+      end
     end
 
     test "delete", %{xml_fragment: f} do

--- a/test/shared_type/xml_text_test.exs
+++ b/test/shared_type/xml_text_test.exs
@@ -9,7 +9,7 @@ defmodule YexXmlTextTest do
       d1 = Doc.with_options(%Doc.Options{client_id: 1})
       f = Doc.get_xml_fragment(d1, "xml")
       XmlFragment.push(f, XmlTextPrelim.from(""))
-      {:ok, xml} = XmlFragment.get(f, 0)
+      {:ok, xml} = XmlFragment.fetch(f, 0)
       %{doc: d1, xml_text: xml, xml_fragment: f}
     end
 


### PR DESCRIPTION
And add `fetch!`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `fetch/2` and `fetch!/2` functions across various modules, enhancing element retrieval with improved error handling.
	- Deprecated the `get/2` function in favor of the new naming conventions.

- **Bug Fixes**
	- Improved error handling for out-of-bounds access in array and map retrieval functions.

- **Tests**
	- Updated test cases to reflect the new `fetch` and `fetch!` functions, ensuring comprehensive coverage for both successful and erroneous retrieval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->