### PR TITLE
feat: add children method to XmlElement and XmlFragment

### DIFF
--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -4,6 +4,8 @@ defmodule Yex.XmlElement do
 
   """
 
+  alias Yex.Xml
+
   defstruct [
     :doc,
     :reference
@@ -21,6 +23,14 @@ defmodule Yex.XmlElement do
       {:ok, node} -> node
       :error -> nil
     end
+  end
+
+  @spec children(t) :: Enumerable.t(Yex.XmlElement.t() | Yex.XmlText.t())
+  def children(%__MODULE__{} = xml_element) do
+    Stream.unfold(first_child(xml_element), fn
+      nil -> nil
+      xml -> {xml, Xml.next_sibling(xml)}
+    end)
   end
 
   @spec length(t) :: integer()

--- a/lib/shared_type/xml_fragment.ex
+++ b/lib/shared_type/xml_fragment.ex
@@ -4,6 +4,8 @@ defmodule Yex.XmlFragment do
 
   """
 
+  alias Yex.Xml
+
   defstruct [
     :doc,
     :reference
@@ -20,6 +22,14 @@ defmodule Yex.XmlFragment do
       {:ok, node} -> node
       :error -> nil
     end
+  end
+
+  @spec children(t) :: Enumerable.t(Yex.XmlElement.t() | Yex.XmlText.t())
+  def children(%__MODULE__{} = xml_fragment) do
+    Stream.unfold(first_child(xml_fragment), fn
+      nil -> nil
+      xml -> {xml, Xml.next_sibling(xml)}
+    end)
   end
 
   def length(%__MODULE__{} = xml_fragment) do

--- a/test/shared_type/xml_element_test.exs
+++ b/test/shared_type/xml_element_test.exs
@@ -102,6 +102,18 @@ defmodule YexXmlElementTest do
 
       assert "next_content" == Xml.to_string(next_prev)
     end
+
+    test "children", %{xml_element: e} do
+      assert 0 === XmlElement.children(e) |> Enum.count()
+      XmlElement.push(e, XmlTextPrelim.from("test"))
+      XmlElement.push(e, XmlTextPrelim.from("test"))
+      XmlElement.push(e, XmlTextPrelim.from("test"))
+      XmlElement.push(e, XmlElementPrelim.empty("div"))
+      XmlElement.push(e, XmlElementPrelim.empty("div"))
+      XmlElement.push(e, XmlElementPrelim.empty("div"))
+
+      assert 6 === XmlElement.children(e) |> Enum.count()
+    end
   end
 
   describe "XmlElementPrelim" do

--- a/test/shared_type/xml_fragment_test.exs
+++ b/test/shared_type/xml_fragment_test.exs
@@ -84,15 +84,25 @@ defmodule YexXmlFragmentTest do
       XmlFragment.push(f, XmlElementPrelim.empty("div"))
       XmlFragment.push(f, XmlElementPrelim.empty("div"))
 
-      {:ok, last} = XmlFragment.fetch(f, 5)
-
       stream =
-        Stream.unfold(last, fn
+        Stream.unfold(XmlFragment.fetch!(f, 5), fn
           nil -> nil
           xml -> {xml, Yex.Xml.prev_sibling(xml)}
         end)
 
       assert 6 === stream |> Enum.to_list() |> Enum.count()
+    end
+
+    test "children", %{xml_fragment: f} do
+      assert 0 === XmlFragment.children(f) |> Enum.count()
+      XmlFragment.push(f, XmlTextPrelim.from("test"))
+      XmlFragment.push(f, XmlTextPrelim.from("test"))
+      XmlFragment.push(f, XmlTextPrelim.from("test"))
+      XmlFragment.push(f, XmlElementPrelim.empty("div"))
+      XmlFragment.push(f, XmlElementPrelim.empty("div"))
+      XmlFragment.push(f, XmlElementPrelim.empty("div"))
+
+      assert 6 === XmlFragment.children(f) |> Enum.count()
     end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `children` function in both the `XmlElement` and `XmlFragment` modules for retrieving child elements in a structured manner.
- **Bug Fixes**
	- Improved error handling in XML fragment fetching to ensure successful retrieval.
- **Tests**
	- Added new test cases to validate the functionality of the `children` methods in both `XmlElement` and `XmlFragment`, enhancing overall test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->