### PR TITLE
fix: raise error when accessing shared type after deletion

### DIFF
--- a/lib/shared_type/error.ex
+++ b/lib/shared_type/error.ex
@@ -1,0 +1,3 @@
+defmodule Yex.DeletedSharedTypeError do
+  defexception message: ""
+end

--- a/native/yex/src/error.rs
+++ b/native/yex/src/error.rs
@@ -1,4 +1,4 @@
-use rustler::{Atom, NifUntaggedEnum};
+use rustler::{Atom, NifException, NifUntaggedEnum};
 
 #[derive(NifUntaggedEnum)]
 pub enum NifError {
@@ -16,4 +16,14 @@ impl From<rustler::Error> for NifError {
     fn from(_w: rustler::Error) -> NifError {
         NifError::Message("todo".to_string())
     }
+}
+
+#[derive(Debug, NifException)]
+#[module = "Yex.DeletedSharedTypeError"]
+pub struct DeletedSharedTypeError {
+    message: String,
+}
+
+pub fn deleted_error(message: String) -> rustler::Error {
+    rustler::Error::RaiseTerm(Box::new(DeletedSharedTypeError { message }))
 }

--- a/test/shared_type/map_test.exs
+++ b/test/shared_type/map_test.exs
@@ -52,6 +52,19 @@ defmodule Yex.MapTest do
     assert :error == Map.fetch(map, "key2")
   end
 
+  test "raise error when access deleted array" do
+    doc = Doc.new()
+
+    map = Doc.get_map(doc, "map")
+    Map.set(map, "key", MapPrelim.from(%{"key" => "Hello"}))
+    m = Map.fetch!(map, "key")
+    Map.delete(map, "key")
+
+    assert_raise Yex.DeletedSharedTypeError, "Map has been deleted", fn ->
+      Map.set(m, "key", "Hello")
+    end
+  end
+
   test "MapPrelim" do
     doc = Doc.new()
 


### PR DESCRIPTION
Until now, it was undefined behavior

https://github.com/y-crdt/y-crdt/issues/493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom exception for better error handling when shared types are deleted.
  - Enhanced error reporting for array, map, text, and XML operations to manage deleted states more effectively.

- **Bug Fixes**
  - Improved robustness of operations on arrays, maps, texts, and XML nodes to prevent actions on deleted references.

- **Tests**
  - Added a test case to verify error handling when accessing deleted map entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->