### PR TITLE
feat: shared types can be compared on Elixir

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -148,7 +148,4 @@ defmodule Yex.Nif.Util do
   @moduledoc false
   def unwrap_ok_tuple({:ok, {}}), do: :ok
   def unwrap_ok_tuple(other), do: other
-  def unwrap_tuple({:ok, {}}), do: :ok
-  def unwrap_tuple({:error, {}}), do: :error
-  def unwrap_tuple(other), do: other
 end

--- a/lib/shared_type/array.ex
+++ b/lib/shared_type/array.ex
@@ -49,7 +49,6 @@ defmodule Yex.Array do
     index = if index < 0, do: __MODULE__.length(array) + index, else: index
 
     Yex.Nif.array_delete_range(array, cur_txn(array), index, length)
-    |> Yex.Nif.Util.unwrap_ok_tuple()
   end
 
   @doc """
@@ -73,7 +72,7 @@ defmodule Yex.Array do
   @spec fetch(t, integer()) :: {:ok, term()} | :error
   def fetch(%__MODULE__{} = array, index) do
     index = if index < 0, do: __MODULE__.length(array) + index, else: index
-    Yex.Nif.array_get(array, cur_txn(array), index) |> Yex.Nif.Util.unwrap_tuple()
+    Yex.Nif.array_get(array, cur_txn(array), index)
   end
 
   @spec fetch!(t, integer()) :: term()

--- a/lib/shared_type/map.ex
+++ b/lib/shared_type/map.ex
@@ -22,7 +22,7 @@ defmodule Yex.Map do
   """
   @spec set(t, term(), term()) :: term()
   def set(%__MODULE__{} = map, key, content) do
-    Yex.Nif.map_set(map, cur_txn(map), key, content) |> Yex.Nif.Util.unwrap_tuple()
+    Yex.Nif.map_set(map, cur_txn(map), key, content)
   end
 
   @doc """
@@ -36,7 +36,7 @@ defmodule Yex.Map do
   """
   @spec delete(t, term()) :: :ok
   def delete(%__MODULE__{} = map, key) do
-    Yex.Nif.map_delete(map, cur_txn(map), key) |> Yex.Nif.Util.unwrap_tuple()
+    Yex.Nif.map_delete(map, cur_txn(map), key)
   end
 
   @doc """
@@ -69,7 +69,7 @@ defmodule Yex.Map do
   """
   @spec fetch(t, binary()) :: {:ok, term()} | :error
   def fetch(%__MODULE__{} = map, key) do
-    Yex.Nif.map_get(map, cur_txn(map), key) |> Yex.Nif.Util.unwrap_tuple()
+    Yex.Nif.map_get(map, cur_txn(map), key)
   end
 
   @spec fetch(t, binary()) :: {:ok, term()} | :error

--- a/lib/shared_type/text.ex
+++ b/lib/shared_type/text.ex
@@ -29,7 +29,7 @@ defmodule Yex.Text do
   @spec delete(t, integer(), integer()) :: :ok | :error
   def delete(%__MODULE__{} = text, index, length) do
     index = if index < 0, do: __MODULE__.length(text) + index, else: index
-    Yex.Nif.text_delete(text, cur_txn(text), index, length) |> Yex.Nif.Util.unwrap_ok_tuple()
+    Yex.Nif.text_delete(text, cur_txn(text), index, length)
   end
 
   @spec format(t, integer(), integer(), map()) :: :ok | :error

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -43,10 +43,24 @@ defmodule Yex.XmlElement do
     Yex.Nif.xml_element_insert(xml_element, cur_txn(xml_element), index, content)
   end
 
+  @spec insert_after(
+          t,
+          Yex.XmlElement.t() | Yex.XmlText.t(),
+          Yex.XmlElementPrelim.t() | Yex.XmlTextPrelim.t()
+        ) :: :ok | :error
+  def insert_after(%__MODULE__{} = xml_fragment, ref, content) do
+    index = children(xml_fragment) |> Enum.find_index(&(&1 == ref))
+
+    if index == nil do
+      insert(xml_fragment, 0, content)
+    else
+      insert(xml_fragment, index + 1, content)
+    end
+  end
+
   @spec delete(t, integer(), integer()) :: :ok | :error
   def delete(%__MODULE__{} = xml_element, index, length) do
     Yex.Nif.xml_element_delete_range(xml_element, cur_txn(xml_element), index, length)
-    |> Yex.Nif.Util.unwrap_tuple()
   end
 
   @spec push(t, Yex.XmlElementPrelim.t() | Yex.XmlTextPrelim.t()) :: :ok | :error
@@ -68,7 +82,6 @@ defmodule Yex.XmlElement do
   @spec fetch(t, integer()) :: {:ok, Yex.XmlElement.t() | Yex.XmlText.t()} | :error
   def fetch(%__MODULE__{} = xml_element, index) do
     Yex.Nif.xml_element_get(xml_element, cur_txn(xml_element), index)
-    |> Yex.Nif.Util.unwrap_tuple()
   end
 
   @spec fetch(t, integer()) :: Yex.XmlElement.t() | Yex.XmlText.t()

--- a/lib/shared_type/xml_fragment.ex
+++ b/lib/shared_type/xml_fragment.ex
@@ -40,9 +40,23 @@ defmodule Yex.XmlFragment do
     Yex.Nif.xml_fragment_insert(xml_fragment, cur_txn(xml_fragment), index, content)
   end
 
+  @spec insert_after(
+          t,
+          Yex.XmlElement.t() | Yex.XmlText.t(),
+          Yex.XmlElementPrelim.t() | Yex.XmlTextPrelim.t()
+        ) :: :ok | :error
+  def insert_after(%__MODULE__{} = xml_fragment, ref, content) do
+    index = children(xml_fragment) |> Enum.find_index(&(&1 == ref))
+
+    if index == nil do
+      insert(xml_fragment, 0, content)
+    else
+      insert(xml_fragment, index + 1, content)
+    end
+  end
+
   def delete(%__MODULE__{} = xml_fragment, index, length) do
     Yex.Nif.xml_fragment_delete_range(xml_fragment, cur_txn(xml_fragment), index, length)
-    |> Yex.Nif.Util.unwrap_tuple()
   end
 
   def push(%__MODULE__{} = xml_fragment, content) do
@@ -62,7 +76,6 @@ defmodule Yex.XmlFragment do
   @spec fetch(t, integer()) :: {:ok, Yex.XmlElement.t() | Yex.XmlText.t()} | :error
   def fetch(%__MODULE__{} = xml_fragment, index) do
     Yex.Nif.xml_fragment_get(xml_fragment, cur_txn(xml_fragment), index)
-    |> Yex.Nif.Util.unwrap_tuple()
   end
 
   @spec fetch(t, integer()) :: Yex.XmlElement.t() | Yex.XmlText.t()

--- a/lib/shared_type/xml_text.ex
+++ b/lib/shared_type/xml_text.ex
@@ -27,7 +27,6 @@ defmodule Yex.XmlText do
     index = if index < 0, do: __MODULE__.length(xml_text) + index, else: index
 
     Yex.Nif.xml_text_delete(xml_text, cur_txn(xml_text), index, length)
-    |> Yex.Nif.Util.unwrap_ok_tuple()
   end
 
   @spec format(t, integer(), integer(), map()) :: :ok | :error

--- a/native/yex/Cargo.toml
+++ b/native/yex/Cargo.toml
@@ -10,8 +10,10 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+flexbuffers = "2.0.0"
 rustler = "0.34.0"
 scoped_thread_local = "1.0.0"
+serde = "1.0.210"
 serde_json = "1.0.120"
 yrs = { version ="0.21.0", features=["sync"] }
 

--- a/native/yex/src/array.rs
+++ b/native/yex/src/array.rs
@@ -6,28 +6,26 @@ use crate::{
     atoms,
     doc::{DocResource, TransactionResource},
     error::deleted_error,
-    wrap::NifWrap,
+    shared_type::NifSharedType,
     yinput::NifYInput,
     youtput::NifYOut,
     NifAny,
 };
 
-pub type ArrayRefResource = NifWrap<Hook<ArrayRef>>;
-#[rustler::resource_impl]
-impl rustler::Resource for ArrayRefResource {}
+pub type ArrayRefId = NifSharedType<ArrayRef>;
 
 #[derive(NifStruct)]
 #[module = "Yex.Array"]
 pub struct NifArray {
     doc: ResourceArc<DocResource>,
-    reference: ResourceArc<ArrayRefResource>,
+    reference: ArrayRefId,
 }
 
 impl NifArray {
     pub fn new(doc: ResourceArc<DocResource>, array: ArrayRef) -> Self {
         NifArray {
             doc,
-            reference: ResourceArc::new(array.hook().into()),
+            reference: ArrayRefId::new(array.hook()),
         }
     }
 }

--- a/native/yex/src/lib.rs
+++ b/native/yex/src/lib.rs
@@ -5,6 +5,7 @@ mod awareness;
 mod doc;
 mod error;
 mod map;
+mod shared_type;
 mod subscription;
 mod sync;
 mod text;

--- a/native/yex/src/map.rs
+++ b/native/yex/src/map.rs
@@ -1,27 +1,25 @@
 use crate::atoms;
 use crate::doc::TransactionResource;
 use crate::error::deleted_error;
-use crate::{doc::DocResource, wrap::NifWrap, yinput::NifYInput, youtput::NifYOut, NifAny};
+use crate::shared_type::NifSharedType;
+use crate::{doc::DocResource, yinput::NifYInput, youtput::NifYOut, NifAny};
 use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
 use std::collections::HashMap;
 use yrs::types::ToJson;
 use yrs::*;
 
-pub type MapRefResource = NifWrap<Hook<MapRef>>;
-#[rustler::resource_impl]
-impl rustler::Resource for MapRefResource {}
-
+pub type MapRefId = NifSharedType<MapRef>;
 #[derive(NifStruct)]
 #[module = "Yex.Map"]
 pub struct NifMap {
     doc: ResourceArc<DocResource>,
-    reference: ResourceArc<MapRefResource>,
+    reference: MapRefId,
 }
 impl NifMap {
     pub fn new(doc: ResourceArc<DocResource>, map: MapRef) -> Self {
         NifMap {
             doc,
-            reference: ResourceArc::new(map.hook().into()),
+            reference: MapRefId::new(map.hook()),
         }
     }
 }

--- a/native/yex/src/shared_type.rs
+++ b/native/yex/src/shared_type.rs
@@ -1,0 +1,39 @@
+use rustler::{Decoder, Encoder, Env, NifResult, Term};
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+use yrs::Hook;
+
+use crate::wrap::encode_binary_slice_to_term;
+
+pub struct NifSharedType<T> {
+    hook: Hook<T>,
+}
+impl<T> NifSharedType<T> {
+    pub fn new(v: Hook<T>) -> Self {
+        Self { hook: v }
+    }
+}
+impl<T> Deref for NifSharedType<T> {
+    type Target = Hook<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.hook
+    }
+}
+impl<'de, 'a: 'de, T> Encoder for NifSharedType<T> {
+    fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
+        let mut s = flexbuffers::FlexbufferSerializer::new();
+
+        self.hook.serialize(&mut s).unwrap();
+        encode_binary_slice_to_term(env, s.view())
+    }
+}
+impl<'a, T: 'a> Decoder<'a> for NifSharedType<T> {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let bin = term.decode_as_binary()?;
+        let r =
+            flexbuffers::Reader::get_root(bin.as_slice()).map_err(|_e| rustler::Error::BadArg)?;
+        let hook = Hook::<T>::deserialize(r).map_err(|_e| rustler::Error::BadArg)?;
+        Ok(NifSharedType::new(hook))
+    }
+}

--- a/native/yex/src/text.rs
+++ b/native/yex/src/text.rs
@@ -9,26 +9,24 @@ use crate::{
     atoms,
     doc::{DocResource, TransactionResource},
     error::deleted_error,
-    wrap::NifWrap,
+    shared_type::NifSharedType,
     yinput::NifYInputDelta,
     youtput::NifYOut,
 };
 
-pub type TextRefResource = NifWrap<Hook<TextRef>>;
-#[rustler::resource_impl]
-impl rustler::Resource for TextRefResource {}
+pub type TextRefId = NifSharedType<TextRef>;
 
 #[derive(NifStruct)]
 #[module = "Yex.Text"]
 pub struct NifText {
     doc: ResourceArc<DocResource>,
-    reference: ResourceArc<TextRefResource>,
+    reference: TextRefId,
 }
 impl NifText {
     pub fn new(doc: ResourceArc<DocResource>, text: TextRef) -> Self {
         NifText {
             doc,
-            reference: ResourceArc::new(text.hook().into()),
+            reference: TextRefId::new(text.hook()),
         }
     }
 }

--- a/native/yex/src/xml.rs
+++ b/native/yex/src/xml.rs
@@ -9,37 +9,29 @@ use crate::{
     atoms,
     doc::{DocResource, TransactionResource},
     error::deleted_error,
+    shared_type::NifSharedType,
     text::encode_diffs,
-    wrap::NifWrap,
     yinput::{NifXmlIn, NifYInputDelta},
     youtput::NifYOut,
     ENV,
 };
 
-pub type XmlFragmentResource = NifWrap<Hook<XmlFragmentRef>>;
-#[rustler::resource_impl]
-impl rustler::Resource for XmlFragmentResource {}
-
-pub type XmlElementResource = NifWrap<Hook<XmlElementRef>>;
-#[rustler::resource_impl]
-impl rustler::Resource for XmlElementResource {}
-
-pub type XmlTextResource = NifWrap<Hook<XmlTextRef>>;
-#[rustler::resource_impl]
-impl rustler::Resource for XmlTextResource {}
+pub type XmlFragmentId = NifSharedType<XmlFragmentRef>;
+pub type XmlElementId = NifSharedType<XmlElementRef>;
+pub type XmlTextId = NifSharedType<XmlTextRef>;
 
 #[derive(NifStruct)]
 #[module = "Yex.XmlFragment"]
 pub struct NifXmlFragment {
     doc: ResourceArc<DocResource>,
-    reference: ResourceArc<XmlFragmentResource>,
+    reference: XmlFragmentId,
 }
 
 impl NifXmlFragment {
     pub fn new(doc: ResourceArc<DocResource>, xml: XmlFragmentRef) -> Self {
         Self {
             doc,
-            reference: ResourceArc::new(xml.hook().into()),
+            reference: XmlFragmentId::new(xml.hook()),
         }
     }
 }
@@ -48,14 +40,14 @@ impl NifXmlFragment {
 #[module = "Yex.XmlElement"]
 pub struct NifXmlElement {
     doc: ResourceArc<DocResource>,
-    reference: ResourceArc<XmlElementResource>,
+    reference: XmlElementId,
 }
 
 impl NifXmlElement {
     pub fn new(doc: ResourceArc<DocResource>, xml: XmlElementRef) -> Self {
         Self {
             doc,
-            reference: ResourceArc::new(xml.hook().into()),
+            reference: XmlElementId::new(xml.hook()),
         }
     }
 }
@@ -64,14 +56,14 @@ impl NifXmlElement {
 #[module = "Yex.XmlText"]
 pub struct NifXmlText {
     doc: ResourceArc<DocResource>,
-    reference: ResourceArc<XmlTextResource>,
+    reference: XmlTextId,
 }
 
 impl NifXmlText {
     pub fn new(doc: ResourceArc<DocResource>, xml: XmlTextRef) -> Self {
         Self {
             doc,
-            reference: ResourceArc::new(xml.hook().into()),
+            reference: XmlTextId::new(xml.hook()),
         }
     }
 }

--- a/test/shared_type/array_test.exs
+++ b/test/shared_type/array_test.exs
@@ -13,6 +13,15 @@ defmodule Yex.ArrayTest do
     assert 1 == Array.length(array)
   end
 
+  test "insert_after" do
+    doc = Doc.new()
+
+    array = Doc.get_array(doc, "array")
+
+    Array.insert(array, 0, "Hello")
+    assert 1 == Array.length(array)
+  end
+
   test "push" do
     doc = Doc.new()
 
@@ -52,6 +61,15 @@ defmodule Yex.ArrayTest do
     end
 
     assert "Hello2" == Array.fetch!(array, -1)
+  end
+
+  test "compare" do
+    doc = Doc.new()
+
+    array1 = Doc.get_array(doc, "array")
+    array2 = Doc.get_array(doc, "array")
+
+    assert array1 == array2
   end
 
   test "unshift" do

--- a/test/shared_type/map_test.exs
+++ b/test/shared_type/map_test.exs
@@ -13,6 +13,17 @@ defmodule Yex.MapTest do
     assert 1 == Map.size(map)
   end
 
+  test "compare" do
+    doc = Doc.new()
+
+    map1 = Doc.get_map(doc, "map")
+    map2 = Doc.get_map(doc, "map")
+    map3 = Doc.get_map(doc, "map3")
+
+    assert map1 == map2
+    assert map1 != map3
+  end
+
   test "fetch" do
     doc = Doc.new()
 

--- a/test/shared_type/text_test.exs
+++ b/test/shared_type/text_test.exs
@@ -158,4 +158,16 @@ defmodule Yex.TextTest do
     assert [%{insert: "1"}, %{insert: "234", attributes: %{"bold" => true}}, %{insert: "56"}] ==
              Text.to_delta(text)
   end
+
+  test "compare" do
+    doc = Doc.new()
+
+    text1 = Doc.get_text(doc, "text")
+    text2 = Doc.get_text(doc, "text")
+
+    assert text1 == text2
+    text3 = Doc.get_text(doc, "text2")
+
+    assert text1 != text3
+  end
 end

--- a/test/shared_type/xml_element_test.exs
+++ b/test/shared_type/xml_element_test.exs
@@ -13,6 +13,15 @@ defmodule YexXmlElementTest do
       %{doc: d1, xml_element: xml, xml_fragment: f}
     end
 
+    test "compare", %{doc: doc} do
+      xml1 = Doc.get_xml_fragment(doc, "xml")
+      xml2 = Doc.get_xml_fragment(doc, "xml")
+
+      assert xml1 == xml2
+      xml3 = Doc.get_xml_fragment(doc, "xml3")
+      assert xml1 != xml3
+    end
+
     test "fetch", %{xml_element: xml} do
       XmlElement.push(xml, XmlElementPrelim.empty("div"))
 
@@ -53,6 +62,17 @@ defmodule YexXmlElementTest do
       {:ok, %XmlText{}} = XmlElement.fetch(xml, 0)
       XmlElement.unshift(xml, XmlElementPrelim.empty("div"))
       {:ok, %XmlElement{}} = XmlElement.fetch(xml, 0)
+    end
+
+    test "insert_after", %{xml_element: xml} do
+      XmlElement.push(xml, XmlTextPrelim.from("1"))
+      XmlElement.push(xml, XmlTextPrelim.from("2"))
+      XmlElement.push(xml, XmlTextPrelim.from("3"))
+      assert text2 = XmlElement.fetch!(xml, 1)
+      XmlElement.insert_after(xml, text2, XmlElementPrelim.empty("div"))
+      assert "<div>12<div></div>3</div>" = XmlElement.to_string(xml)
+      XmlElement.insert_after(xml, nil, XmlElementPrelim.empty("div"))
+      assert "<div><div></div>12<div></div>3</div>" = XmlElement.to_string(xml)
     end
 
     test "delete", %{xml_element: xml} do

--- a/test/shared_type/xml_fragment_test.exs
+++ b/test/shared_type/xml_fragment_test.exs
@@ -24,6 +24,28 @@ defmodule YexXmlFragmentTest do
       {:ok, %XmlElement{}} = XmlFragment.fetch(f, 0)
     end
 
+    test "insert_after", %{xml_fragment: f} do
+      XmlFragment.push(f, XmlTextPrelim.from("1"))
+      XmlFragment.push(f, XmlTextPrelim.from("2"))
+      XmlFragment.push(f, XmlTextPrelim.from("3"))
+      assert text2 = XmlFragment.fetch!(f, 1)
+      XmlFragment.insert_after(f, text2, XmlElementPrelim.empty("div"))
+      assert "12<div></div>3" = XmlFragment.to_string(f)
+      XmlFragment.insert_after(f, nil, XmlElementPrelim.empty("div"))
+      assert "<div></div>12<div></div>3" = XmlFragment.to_string(f)
+    end
+
+    test "compare", %{xml_fragment: f} do
+      XmlFragment.push(f, XmlElementPrelim.empty("div"))
+      XmlFragment.push(f, XmlElementPrelim.empty("div"))
+      xml1 = XmlFragment.fetch!(f, 0)
+      xml2 = XmlFragment.fetch!(f, 0)
+
+      assert xml1 == xml2
+      xml3 = XmlFragment.fetch!(f, 1)
+      assert xml1 != xml3
+    end
+
     test "fetch", %{xml_fragment: xml} do
       XmlFragment.push(xml, XmlElementPrelim.empty("div"))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new `insert_after` functions in `Yex.XmlElement` and `Yex.XmlFragment` modules for enhanced XML manipulation.
  
- **Bug Fixes**
  - Simplified return handling across several functions in `Yex.Array`, `Yex.Map`, `Yex.Text`, and XML modules to improve error management and output consistency.

- **Tests**
  - Added new test cases for `Array`, `Map`, `Text`, `XmlElement`, and `XmlFragment` modules to improve coverage and validate new functionalities. 

- **Chores**
  - Updated dependencies in `Cargo.toml` to include `flexbuffers` and `serde` for improved serialization capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->