### PR TITLE
add parent method to xml type

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -68,6 +68,8 @@ defmodule Yex.Nif do
   def xml_fragment_to_string(_xml_fragment, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def xml_fragment_length(_xml_fragment, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
 
+  def xml_fragment_parent(_xml_fragment, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
+
   def xml_element_insert(_xml_element, _cur_txn, _index, _content),
     do: :erlang.nif_error(:nif_not_loaded)
 
@@ -92,6 +94,8 @@ defmodule Yex.Nif do
   def xml_element_prev_sibling(_xml_element, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def xml_element_to_string(_xml_element, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
 
+  def xml_element_parent(_xml_element, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
+
   def xml_text_insert(_xml_text, _cur_txn, _index, _content),
     do: :erlang.nif_error(:nif_not_loaded)
 
@@ -111,6 +115,8 @@ defmodule Yex.Nif do
   def xml_text_prev_sibling(_xml_text, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def xml_text_to_delta(_xml_text, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def xml_text_to_string(_xml_text, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
+
+  def xml_text_parent(_xml_text, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
 
   def encode_state_vector_v1(_doc, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def encode_state_as_update_v1(_doc, _cur_txn, _diff), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/shared_type/xml.ex
+++ b/lib/shared_type/xml.ex
@@ -1,17 +1,20 @@
 defprotocol Yex.Xml do
   def next_sibling(xml)
   def prev_sibling(xml)
+  def parent(xml)
   def to_string(xml)
 end
 
 defimpl Yex.Xml, for: Yex.XmlText do
   defdelegate next_sibling(xml), to: Yex.XmlText
   defdelegate prev_sibling(xml), to: Yex.XmlText
+  defdelegate parent(xml), to: Yex.XmlText
   defdelegate to_string(xml), to: Yex.XmlText
 end
 
 defimpl Yex.Xml, for: Yex.XmlElement do
   defdelegate next_sibling(xml), to: Yex.XmlElement
   defdelegate prev_sibling(xml), to: Yex.XmlElement
+  defdelegate parent(xml), to: Yex.XmlElement
   defdelegate to_string(xml), to: Yex.XmlElement
 end

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -128,6 +128,9 @@ defmodule Yex.XmlElement do
     Yex.Nif.xml_element_prev_sibling(xml_element, cur_txn(xml_element))
   end
 
+  @doc """
+  The parent that holds this type. Is null if this xml is a top-level XML type.
+  """
   @spec parent(t) :: Yex.XmlElement.t() | Yex.XmlFragment.t() | nil
   def parent(%__MODULE__{} = xml_element) do
     Yex.Nif.xml_element_parent(xml_element, cur_txn(xml_element))

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -122,6 +122,11 @@ defmodule Yex.XmlElement do
     Yex.Nif.xml_element_prev_sibling(xml_element, cur_txn(xml_element))
   end
 
+  @spec parent(t) :: Yex.XmlElement.t() | Yex.XmlFragment.t() | nil
+  def parent(%__MODULE__{} = xml_element) do
+    Yex.Nif.xml_element_parent(xml_element, cur_txn(xml_element))
+  end
+
   @spec to_string(t) :: binary()
   def to_string(%__MODULE__{} = xml_element) do
     Yex.Nif.xml_element_to_string(xml_element, cur_txn(xml_element))

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -112,11 +112,17 @@ defmodule Yex.XmlElement do
     Yex.Nif.xml_element_get_attributes(xml_element, cur_txn(xml_element))
   end
 
+  @doc """
+  The next sibling of this type. Is null if this is the last child of its parent.
+  """
   @spec next_sibling(t) :: Yex.XmlElement.t() | Yex.XmlText.t() | nil
   def next_sibling(%__MODULE__{} = xml_element) do
     Yex.Nif.xml_element_next_sibling(xml_element, cur_txn(xml_element))
   end
 
+  @doc """
+  The previous sibling of this type. Is null if this is the first child of its parent.
+  """
   @spec prev_sibling(t) :: Yex.XmlElement.t() | Yex.XmlText.t() | nil
   def prev_sibling(%__MODULE__{} = xml_element) do
     Yex.Nif.xml_element_prev_sibling(xml_element, cur_txn(xml_element))

--- a/lib/shared_type/xml_fragment.ex
+++ b/lib/shared_type/xml_fragment.ex
@@ -117,7 +117,7 @@ defmodule Yex.XmlFragmentPrelim do
       "<div></div>"
 
   """
-  defstruct [:tag, :attributes, :children]
+  defstruct [:children]
 
   @type t :: %__MODULE__{
           children: [Yex.XmlElementPrelim.t() | Yex.XmlTextPrelim.t()]

--- a/lib/shared_type/xml_fragment.ex
+++ b/lib/shared_type/xml_fragment.ex
@@ -32,6 +32,9 @@ defmodule Yex.XmlFragment do
     end)
   end
 
+  @doc """
+  The parent that holds this type. Is null if this xml is a top-level XML type.
+  """
   @spec parent(t) :: Yex.XmlElement.t() | Yex.XmlFragment.t() | nil
   def parent(%__MODULE__{} = xml_fragment) do
     Yex.Nif.xml_fragment_parent(xml_fragment, cur_txn(xml_fragment))

--- a/lib/shared_type/xml_fragment.ex
+++ b/lib/shared_type/xml_fragment.ex
@@ -32,6 +32,11 @@ defmodule Yex.XmlFragment do
     end)
   end
 
+  @spec parent(t) :: Yex.XmlElement.t() | Yex.XmlFragment.t() | nil
+  def parent(%__MODULE__{} = xml_fragment) do
+    Yex.Nif.xml_fragment_parent(xml_fragment, cur_txn(xml_fragment))
+  end
+
   def length(%__MODULE__{} = xml_fragment) do
     Yex.Nif.xml_fragment_length(xml_fragment, cur_txn(xml_fragment))
   end
@@ -93,5 +98,31 @@ defmodule Yex.XmlFragment do
 
   defp cur_txn(%__MODULE__{doc: doc_ref}) do
     Process.get(doc_ref, nil)
+  end
+end
+
+defmodule Yex.XmlFragmentPrelim do
+  @moduledoc """
+  A preliminary xml fragment. It can be used to early initialize the contents of a XmlFragment.
+
+  ## Examples
+      iex> doc = Yex.Doc.new()
+      iex> array = Yex.Doc.get_array(doc, "array")
+      iex> Yex.Array.insert(array, 0,  Yex.XmlFragmentPrelim.new([Yex.XmlElementPrelim.empty("div")]))
+      iex> {:ok, %Yex.XmlFragment{} = fragment} = Yex.Array.fetch(array, 0)
+      iex> Yex.XmlFragment.to_string(fragment)
+      "<div></div>"
+
+  """
+  defstruct [:tag, :attributes, :children]
+
+  @type t :: %__MODULE__{
+          children: [Yex.XmlElementPrelim.t() | Yex.XmlTextPrelim.t()]
+        }
+
+  def new(children) do
+    %__MODULE__{
+      children: Enum.to_list(children)
+    }
   end
 end

--- a/lib/shared_type/xml_text.ex
+++ b/lib/shared_type/xml_text.ex
@@ -74,6 +74,9 @@ defmodule Yex.XmlText do
     Yex.Nif.xml_text_prev_sibling(xml_text, cur_txn(xml_text))
   end
 
+  @doc """
+  The parent that holds this type. Is null if this xml is a top-level XML type.
+  """
   @spec parent(t) :: Yex.XmlElement.t() | Yex.XmlFragment.t() | nil
   def parent(%__MODULE__{} = xml_text) do
     Yex.Nif.xml_text_parent(xml_text, cur_txn(xml_text))

--- a/lib/shared_type/xml_text.ex
+++ b/lib/shared_type/xml_text.ex
@@ -10,6 +10,11 @@ defmodule Yex.XmlText do
     :reference
   ]
 
+  @type t :: %__MODULE__{
+          doc: reference(),
+          reference: reference()
+        }
+
   @type delta :: Yex.Text.delta()
 
   @spec insert(t, integer(), Yex.input_type()) :: :ok | :error
@@ -53,16 +58,19 @@ defmodule Yex.XmlText do
     Yex.Nif.xml_text_length(xml_text, cur_txn(xml_text))
   end
 
-  @type t :: %__MODULE__{
-          doc: reference(),
-          reference: reference()
-        }
+  @spec next_sibling(t) :: Yex.XmlElement.t() | Yex.XmlText.t() | nil
   def next_sibling(%__MODULE__{} = xml_text) do
     Yex.Nif.xml_text_next_sibling(xml_text, cur_txn(xml_text))
   end
 
+  @spec prev_sibling(t) :: Yex.XmlElement.t() | Yex.XmlText.t() | nil
   def prev_sibling(%__MODULE__{} = xml_text) do
     Yex.Nif.xml_text_prev_sibling(xml_text, cur_txn(xml_text))
+  end
+
+  @spec parent(t) :: Yex.XmlElement.t() | Yex.XmlFragment.t() | nil
+  def parent(%__MODULE__{} = xml_text) do
+    Yex.Nif.xml_text_parent(xml_text, cur_txn(xml_text))
   end
 
   defp cur_txn(%__MODULE__{doc: doc_ref}) do

--- a/lib/shared_type/xml_text.ex
+++ b/lib/shared_type/xml_text.ex
@@ -58,11 +58,17 @@ defmodule Yex.XmlText do
     Yex.Nif.xml_text_length(xml_text, cur_txn(xml_text))
   end
 
+  @doc """
+  The next sibling of this type. Is null if this is the last child of its parent.
+  """
   @spec next_sibling(t) :: Yex.XmlElement.t() | Yex.XmlText.t() | nil
   def next_sibling(%__MODULE__{} = xml_text) do
     Yex.Nif.xml_text_next_sibling(xml_text, cur_txn(xml_text))
   end
 
+  @doc """
+  The previous sibling of this type. Is null if this is the first child of its parent.
+  """
   @spec prev_sibling(t) :: Yex.XmlElement.t() | Yex.XmlText.t() | nil
   def prev_sibling(%__MODULE__{} = xml_text) do
     Yex.Nif.xml_text_prev_sibling(xml_text, cur_txn(xml_text))

--- a/native/yex/src/xml.rs
+++ b/native/yex/src/xml.rs
@@ -151,6 +151,22 @@ fn xml_fragment_to_string(
 }
 
 #[rustler::nif]
+fn xml_fragment_parent(
+    xml: NifXmlFragment,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+) -> NifResult<Option<NifYOut>> {
+    let doc = xml.doc;
+    doc.readonly(current_transaction, |txn| {
+        let xml = xml
+            .reference
+            .get(txn)
+            .ok_or(deleted_error("Xml has been deleted".to_string()))?;
+
+        Ok(xml.parent().map(|b| NifYOut::from_xml_out(b, doc.clone())))
+    })
+}
+
+#[rustler::nif]
 fn xml_element_insert(
     env: Env<'_>,
     xml: NifXmlElement,
@@ -334,6 +350,22 @@ fn xml_element_prev_sibling(
 }
 
 #[rustler::nif]
+fn xml_element_parent(
+    xml: NifXmlElement,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+) -> NifResult<Option<NifYOut>> {
+    let doc = xml.doc;
+    doc.readonly(current_transaction, |txn| {
+        let xml = xml
+            .reference
+            .get(txn)
+            .ok_or(deleted_error("Xml has been deleted".to_string()))?;
+
+        Ok(xml.parent().map(|b| NifYOut::from_xml_out(b, doc.clone())))
+    })
+}
+
+#[rustler::nif]
 fn xml_text_insert(
     env: Env<'_>,
     text: NifXmlText,
@@ -500,5 +532,21 @@ fn xml_text_to_string(
             .get(txn)
             .ok_or(deleted_error("Xml has been deleted".to_string()))?;
         Ok(text.get_string(txn).into())
+    })
+}
+
+#[rustler::nif]
+fn xml_text_parent(
+    xml: NifXmlText,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+) -> NifResult<Option<NifYOut>> {
+    let doc = xml.doc;
+    doc.readonly(current_transaction, |txn| {
+        let xml = xml
+            .reference
+            .get(txn)
+            .ok_or(deleted_error("Xml has been deleted".to_string()))?;
+
+        Ok(xml.parent().map(|b| NifYOut::from_xml_out(b, doc.clone())))
     })
 }

--- a/native/yex/src/yinput.rs
+++ b/native/yex/src/yinput.rs
@@ -158,7 +158,7 @@ impl Prelim for NifYInput {
                 (ItemContent::Type(inner), Some(self))
             }
             NifYInput::XmlFragmentPrelim(_) => {
-                let inner = Branch::new(TypeRef::XmlText);
+                let inner = Branch::new(TypeRef::XmlFragment);
                 (ItemContent::Type(inner), Some(self))
             }
         }

--- a/test/shared_type/xml_element_test.exs
+++ b/test/shared_type/xml_element_test.exs
@@ -96,6 +96,12 @@ defmodule YexXmlElementTest do
       assert %{"width" => "12"} == XmlElement.get_attributes(xml1)
     end
 
+    test "parent", %{xml_element: e, xml_fragment: xml_fragment} do
+      parent = Yex.Xml.parent(e)
+
+      assert parent == xml_fragment
+    end
+
     test "first_child", %{xml_element: e} do
       assert nil == XmlElement.first_child(e)
       XmlElement.push(e, XmlTextPrelim.from(""))

--- a/test/shared_type/xml_fragment_test.exs
+++ b/test/shared_type/xml_fragment_test.exs
@@ -2,6 +2,7 @@ defmodule YexXmlFragmentTest do
   use ExUnit.Case
   alias Yex.{Doc, XmlFragment, XmlElement, XmlElementPrelim, XmlText, XmlTextPrelim}
   doctest XmlFragment
+  doctest Yex.XmlFragmentPrelim
 
   setup do
     doc = Doc.with_options(%Doc.Options{client_id: 1})
@@ -113,6 +114,10 @@ defmodule YexXmlFragmentTest do
         end)
 
       assert 6 === stream |> Enum.to_list() |> Enum.count()
+    end
+
+    test "parent", %{xml_fragment: f} do
+      assert nil == XmlFragment.parent(f)
     end
 
     test "children", %{xml_fragment: f} do

--- a/test/shared_type/xml_text_test.exs
+++ b/test/shared_type/xml_text_test.exs
@@ -142,5 +142,11 @@ defmodule YexXmlTextTest do
 
       assert "content" == XmlText.to_string(next_prev)
     end
+
+    test "parent", %{xml_text: text, xml_fragment: xml_fragment} do
+      parent = Yex.Xml.parent(text)
+
+      assert parent == xml_fragment
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new functions for retrieving parent elements in XML structures, enhancing navigation capabilities.
  - Added `parent` function to the `Yex.Xml` protocol for handling XML relationships.
  - Enhanced `Yex.XmlElement`, `Yex.XmlText`, and `Yex.XmlFragment` modules with new functions for sibling and parent retrieval.

- **Tests**
  - Added test cases to verify the functionality of the new parent retrieval methods for XML elements, text, and fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->