### PR TITLE
Lower the requirement of rustler_precompiled

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Yex.MixProject do
   defp deps do
     [
       {:rustler, ">= 0.0.0", optional: true},
-      {:rustler_precompiled, "~> 0.8"},
+      {:rustler_precompiled, ">= 0.6.0"},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Change down the requirements version because it cannot be used at the same time as libraries that use older versions of rustler_precompiled, such as html5ever.