### PR TITLE
feat: add insert_list to Array type

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -41,6 +41,7 @@ defmodule Yex.Nif do
   def text_length(_text, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
 
   def array_insert(_array, _cur_txn, _index, _value), do: :erlang.nif_error(:nif_not_loaded)
+  def array_insert_list(_array, _cur_txn, _index, _values), do: :erlang.nif_error(:nif_not_loaded)
   def array_length(_array, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def array_to_list(_array, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def array_get(_array, _cur_txn, _index), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/shared_type/array.ex
+++ b/lib/shared_type/array.ex
@@ -20,6 +20,21 @@ defmodule Yex.Array do
   end
 
   @doc """
+  Insert contents at the specified index.
+
+  ## Example
+      iex> doc = Yex.Doc.new()
+      iex> array = Yex.Doc.get_array(doc, "array")
+      iex> Yex.Array.insert_list(array, 0, [1,2,3,4,5])
+      iex> Yex.Array.to_json(array)
+      [1, 2, 3, 4, 5]
+  """
+  @spec insert_list(t, integer(), list()) :: :ok
+  def insert_list(%__MODULE__{} = array, index, contents) do
+    Yex.Nif.array_insert_list(array, cur_txn(array), index, contents)
+  end
+
+  @doc """
   Push content to the end of the array.
   """
   def push(%__MODULE__{} = array, content) do

--- a/native/yex/src/array.rs
+++ b/native/yex/src/array.rs
@@ -48,6 +48,23 @@ fn array_insert(
     })
 }
 #[rustler::nif]
+fn array_insert_list(
+    env: Env<'_>,
+    array: NifArray,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+    index: u32,
+    values: Vec<NifAny>,
+) -> NifResult<Atom> {
+    array.doc.mutably(env, current_transaction, |txn| {
+        let array = array
+            .reference
+            .get(txn)
+            .ok_or(deleted_error("Array has been deleted".to_string()))?;
+        array.insert_range(txn, index, values.into_iter().map(|a| a.0.clone()));
+        Ok(atoms::ok())
+    })
+}
+#[rustler::nif]
 fn array_length(
     array: NifArray,
     current_transaction: Option<ResourceArc<TransactionResource>>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to insert multiple values into an array at a specified index through the new `insert_list` function in the `Yex.Array` module.
	- Added a new function `array_insert_list` in the `Yex.Nif` module for enhanced array operations.

- **Documentation**
	- Updated documentation for the `insert/3` function to clarify its purpose and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->