### PR TITLE
Add metadata to the monitor methods

### DIFF
--- a/lib/doc.ex
+++ b/lib/doc.ex
@@ -108,14 +108,15 @@ defmodule Yex.Doc do
 
   @doc """
   Monitor document updates.
+   You can pass metadata as an option. This value is passed as the fourth element of the message.If omitted, it will be passed as a structure of Doc itself.
   """
-  @spec monitor_update(t) :: {:ok, reference()} | {:error, term()}
-  def monitor_update(%__MODULE__{} = doc) do
-    monitor_update_v1(doc)
+  @spec monitor_update(t, keyword) :: {:ok, reference()} | {:error, term()}
+  def monitor_update(%__MODULE__{} = doc, opt \\ []) do
+    monitor_update_v1(doc, opt)
   end
 
-  def monitor_update_v1(%__MODULE__{} = doc) do
-    case Yex.Nif.doc_monitor_update_v1(doc, self()) do
+  def monitor_update_v1(%__MODULE__{} = doc, opt \\ []) do
+    case Yex.Nif.doc_monitor_update_v1(doc, self(), Keyword.get(opt, :metadata, doc)) do
       {:ok, ref} ->
         # Subscription should not be automatically released by gc, so put it in the process dictionary
         Process.put(__MODULE__.Subscriptions, [ref | Process.get(__MODULE__.Subscriptions, [])])
@@ -126,8 +127,8 @@ defmodule Yex.Doc do
     end
   end
 
-  def monitor_update_v2(%__MODULE__{} = doc) do
-    case Yex.Nif.doc_monitor_update_v2(doc, self()) do
+  def monitor_update_v2(%__MODULE__{} = doc, opt \\ []) do
+    case Yex.Nif.doc_monitor_update_v2(doc, self(), Keyword.get(opt, :metadata, doc)) do
       {:ok, ref} ->
         # Subscription should not be automatically released by gc, so put it in the process dictionary
         Process.put(__MODULE__.Subscriptions, [ref | Process.get(__MODULE__.Subscriptions, [])])

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -17,8 +17,8 @@ defmodule Yex.Nif do
   def doc_get_or_insert_array(_doc, _name), do: :erlang.nif_error(:nif_not_loaded)
   def doc_get_or_insert_map(_doc, _name), do: :erlang.nif_error(:nif_not_loaded)
   def doc_get_or_insert_xml_fragment(_doc, _name), do: :erlang.nif_error(:nif_not_loaded)
-  def doc_monitor_update_v1(_doc, _pid), do: :erlang.nif_error(:nif_not_loaded)
-  def doc_monitor_update_v2(_doc, _pid), do: :erlang.nif_error(:nif_not_loaded)
+  def doc_monitor_update_v1(_doc, _pid, _metadata), do: :erlang.nif_error(:nif_not_loaded)
+  def doc_monitor_update_v2(_doc, _pid, _metadata), do: :erlang.nif_error(:nif_not_loaded)
 
   def sub_unsubscribe(_sub), do: :erlang.nif_error(:nif_not_loaded)
 
@@ -140,8 +140,12 @@ defmodule Yex.Nif do
   def awareness_get_local_state(_awareness), do: :erlang.nif_error(:nif_not_loaded)
   def awareness_set_local_state(_awareness, _map), do: :erlang.nif_error(:nif_not_loaded)
   def awareness_clean_local_state(_awareness), do: :erlang.nif_error(:nif_not_loaded)
-  def awareness_monitor_update(_awareness, _pid), do: :erlang.nif_error(:nif_not_loaded)
-  def awareness_monitor_change(_awareness, _pid), do: :erlang.nif_error(:nif_not_loaded)
+
+  def awareness_monitor_update(_awareness, _pid, _metadata),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def awareness_monitor_change(_awareness, _pid, _metadata),
+    do: :erlang.nif_error(:nif_not_loaded)
 
   def awareness_encode_update_v1(_awareness, _clients), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/native/yex/src/lib.rs
+++ b/native/yex/src/lib.rs
@@ -8,6 +8,7 @@ mod map;
 mod shared_type;
 mod subscription;
 mod sync;
+mod term_box;
 mod text;
 mod utils;
 mod wrap;

--- a/native/yex/src/subscription.rs
+++ b/native/yex/src/subscription.rs
@@ -11,11 +11,11 @@ impl rustler::Resource for SubscriptionResource {}
 #[rustler::nif]
 fn sub_unsubscribe(env: Env<'_>, sub: ResourceArc<SubscriptionResource>) -> Result<(), NifError> {
     ENV.set(&mut env.clone(), || {
-        if let Ok(mut sub) = sub.0.lock() {
-            *sub = None;
-            Ok(())
-        } else {
-            Err(NifError::Message("Failed to unsubscribe".to_string()))
-        }
+        let mut inner = match sub.0.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *inner = None;
+        Ok(())
     })
 }

--- a/native/yex/src/term_box.rs
+++ b/native/yex/src/term_box.rs
@@ -1,0 +1,47 @@
+use rustler::env::OwnedEnv;
+use rustler::env::SavedTerm;
+use rustler::Env;
+use rustler::Term;
+
+// https://github.com/rusterlium/rustler/issues/333#issuecomment-702236600
+
+pub struct TermBox {
+    inner: std::sync::Mutex<TermBoxContents>,
+}
+
+struct TermBoxContents {
+    owned_env: OwnedEnv,
+    saved_term: SavedTerm,
+}
+
+impl TermBox {
+    pub fn new(term: Term) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(TermBoxContents::new(term)),
+        }
+    }
+
+    pub fn get<'a>(&self, env: Env<'a>) -> Term<'a> {
+        let inner = match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        // Copy over term from owned environment to the target environment
+        inner.owned_env.run(|inner_env| {
+            let term = inner.saved_term.load(inner_env);
+            term.in_env(env)
+        })
+    }
+}
+
+impl TermBoxContents {
+    fn new(term: Term) -> Self {
+        let owned_env = OwnedEnv::new();
+        let saved_term = owned_env.save(term);
+        Self {
+            owned_env: owned_env,
+            saved_term: saved_term,
+        }
+    }
+}

--- a/test/doc_test.exs
+++ b/test/doc_test.exs
@@ -75,6 +75,17 @@ defmodule Yex.DocTest do
     Doc.demonitor_update(monitor_ref)
   end
 
+  test "monitor_update with medatada" do
+    doc = Doc.new()
+    {:ok, monitor_ref} = Doc.monitor_update(doc, metadata: "metadata")
+
+    text1 = Doc.get_text(doc, "text")
+    Text.insert(text1, 0, "HelloWorld")
+
+    assert_receive {:update_v1, _update, nil, "metadata"}
+    Doc.demonitor_update(monitor_ref)
+  end
+
   test "monitor_update_v2" do
     doc = Doc.new()
     {:ok, monitor_ref} = Doc.monitor_update_v2(doc)
@@ -84,6 +95,18 @@ defmodule Yex.DocTest do
 
     assert Text.to_string(text1) == "HelloWorld"
     assert_receive {:update_v2, _update, nil, ^doc}
+    Doc.demonitor_update_v2(monitor_ref)
+  end
+
+  test "monitor_update_v2 with medatada" do
+    doc = Doc.new()
+    {:ok, monitor_ref} = Doc.monitor_update_v2(doc, metadata: "metadata")
+
+    text1 = Doc.get_text(doc, "text")
+    Text.insert(text1, 0, "HelloWorld")
+
+    assert Text.to_string(text1) == "HelloWorld"
+    assert_receive {:update_v2, _update, nil, "metadata"}
     Doc.demonitor_update_v2(monitor_ref)
   end
 

--- a/test/protocols/awareness_test.exs
+++ b/test/protocols/awareness_test.exs
@@ -31,6 +31,15 @@ defmodule Yex.AwarenessTest do
     refute_received {:awareness_update, _, _origin, _awareness}
   end
 
+  test "monitor_update with metadata" do
+    {:ok, awareness} = Awareness.new(Yex.Doc.with_options(%Yex.Doc.Options{client_id: 10}))
+    _monitor_ref = Awareness.monitor_update(awareness, metadata: %{"key" => "value"})
+    Awareness.set_local_state(awareness, %{"key" => "value"})
+
+    assert_received {:awareness_update, %{removed: [], added: [10], updated: []}, _origin,
+                     %{"key" => "value"}}
+  end
+
   test "monitor_change" do
     {:ok, awareness} = Awareness.new(Yex.Doc.with_options(%Yex.Doc.Options{client_id: 10}))
     monitor_ref = Awareness.monitor_change(awareness)
@@ -42,6 +51,15 @@ defmodule Yex.AwarenessTest do
     Awareness.demonitor_change(monitor_ref)
     Awareness.set_local_state(awareness, %{"key2" => "value2"})
     refute_received {:awareness_change, _, _origin, _awareness}
+  end
+
+  test "monitor_change with metadata" do
+    {:ok, awareness} = Awareness.new(Yex.Doc.with_options(%Yex.Doc.Options{client_id: 10}))
+    _monitor_ref = Awareness.monitor_change(awareness, metadata: %{"key" => "value"})
+    Awareness.set_local_state(awareness, %{"key" => "value"})
+
+    assert_received {:awareness_change, %{removed: [], added: [10], updated: []}, _origin,
+                     %{"key" => "value"}}
   end
 
   test "remove_states" do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced monitoring functions now accept optional metadata parameters for improved flexibility during document and awareness updates.
  - Introduced a new `TermBox` struct for safe term management across different environments.

- **Bug Fixes**
  - Improved error handling in the `sub_unsubscribe` function to handle mutex poisoning scenarios effectively.

- **Tests**
  - Added new test cases to validate the functionality of monitoring updates with metadata in both document and awareness modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->