### PR TITLE
fix copied comments

### DIFF
--- a/lib/server/doc_server.ex
+++ b/lib/server/doc_server.ex
@@ -4,7 +4,7 @@ defmodule Yex.DocServer do
 
   `DocServer` defines a module to handle document update messages by yjs.
 
-  ## Example
+  ## Examples
       defmodule MyDocServer do
         use Yex.DocServer
 

--- a/lib/shared_type/array.ex
+++ b/lib/shared_type/array.ex
@@ -22,7 +22,7 @@ defmodule Yex.Array do
   @doc """
   Insert contents at the specified index.
 
-  ## Example
+  ## Examples
       iex> doc = Yex.Doc.new()
       iex> array = Yex.Doc.get_array(doc, "array")
       iex> Yex.Array.insert_list(array, 0, [1,2,3,4,5])
@@ -66,15 +66,6 @@ defmodule Yex.Array do
     Yex.Nif.array_delete_range(array, cur_txn(array), index, length)
   end
 
-  @doc """
-  Get content at the specified index.
-  ## Examples Sync two clients by exchanging the complete document structure
-      iex> doc = Yex.Doc.new()
-      iex> array = Yex.Doc.get_array(doc, "array")
-      iex> Yex.Array.push(array, "Hello")
-      iex> Yex.Array.get(array, 0)
-      {:ok, "Hello"}
-  """
   @deprecated "Rename to `fetch/2`"
   @spec get(t, integer()) :: {:ok, term()} | :error
   def get(array, index) do
@@ -83,6 +74,12 @@ defmodule Yex.Array do
 
   @doc """
   Get content at the specified index.
+  ## Examples pushes a string then fetches it back
+      iex> doc = Yex.Doc.new()
+      iex> array = Yex.Doc.get_array(doc, "array")
+      iex> Yex.Array.push(array, "Hello")
+      iex> Yex.Array.fetch(array, 0)
+      {:ok, "Hello"}
   """
   @spec fetch(t, integer()) :: {:ok, term()} | :error
   def fetch(%__MODULE__{} = array, index) do
@@ -101,7 +98,7 @@ defmodule Yex.Array do
   @doc """
   Returns as list
 
-  ## Examples Sync two clients by exchanging the complete document structure
+  ## Examples adds a few items to an array, then gets them back as Elixir List
       iex> doc = Yex.Doc.new()
       iex> array = Yex.Doc.get_array(doc, "array")
       iex> Yex.Array.push(array, "Hello")
@@ -117,7 +114,7 @@ defmodule Yex.Array do
   @doc """
   Returns the length of the array
 
-  ## Examples Sync two clients by exchanging the complete document structure
+  ## Examples adds a few items to an array and returns its length
       iex> doc = Yex.Doc.new()
       iex> array = Yex.Doc.get_array(doc, "array")
       iex> Yex.Array.push(array, "Hello")
@@ -132,7 +129,7 @@ defmodule Yex.Array do
   @doc """
   Convert to json-compatible format.
 
-  ## Examples Sync two clients by exchanging the complete document structure
+  ## Examples adds a few items to an array and returns as Elixir List
       iex> doc = Yex.Doc.new()
       iex> array = Yex.Doc.get_array(doc, "array")
       iex> Yex.Array.push(array, "Hello")

--- a/lib/shared_type/map.ex
+++ b/lib/shared_type/map.ex
@@ -103,7 +103,7 @@ defmodule Yex.Map do
   @doc """
   Convert to json-compatible format.
 
-  ## Examples Sync two clients by exchanging the complete document structure
+  ## Examples shows a map being created incrementally then returned
       iex> doc = Yex.Doc.new()
       iex> map = Yex.Doc.get_map(doc, "map")
       iex> Yex.Map.set(map, "array", Yex.ArrayPrelim.from(["Hello", "World"]))

--- a/lib/shared_type/text.ex
+++ b/lib/shared_type/text.ex
@@ -40,7 +40,7 @@ defmodule Yex.Text do
   @doc """
   Transforms this type to a Quill Delta
 
-  ## Examples Sync two clients by exchanging the complete document structure
+  ## Examples Syncs two clients by exchanging the complete document structure
       iex> doc = Yex.Doc.new()
       iex> text = Yex.Doc.get_text(doc, "text")
       iex> delta = [%{ "retain" => 1}, %{ "delete" => 3}]
@@ -67,7 +67,7 @@ defmodule Yex.Text do
   @doc """
   Transforms this type to a Quill Delta
 
-  ## Examples Sync two clients by exchanging the complete document structure
+  ## Examples creates a few changes, then gets them back as a batch of change maps
       iex> doc = Yex.Doc.new()
       iex> text = Yex.Doc.get_text(doc, "text")
       iex> Yex.Text.insert(text, 0, "12345")

--- a/lib/y_ex.ex
+++ b/lib/y_ex.ex
@@ -84,7 +84,7 @@ defmodule Yex do
   @doc """
   Apply a document update on the shared document.
 
-  ## Examples Sync two clients by exchanging the complete document structure
+  ## Examples syncs two clients by exchanging the complete document structure
       iex> doc1 = Yex.Doc.new()
       iex> doc2 = Yex.Doc.new()
       iex> {:ok, state1} = Yex.encode_state_as_update(doc1)


### PR DESCRIPTION
It looks like the comments for Yex.apply_update were copied.  Update replaces the copied text that was specific to the original comment with correct explanation.  

Optionally, could just delete the copied text, happy to submit that PR instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation Updates**
	- Enhanced clarity and consistency in documentation across multiple modules.
	- Updated examples for functions to better illustrate their usage.
	- Changed documentation headings for better accuracy (e.g., "Example" to "Examples").
	- Added detailed descriptions for parameters and return values in several callback functions.
  
- **Deprecations**
	- Marked `get/2` function as deprecated in both `Yex.Array` and `Yex.Map`, redirecting users to `fetch/2`.

- **New Features**
	- Introduced `fetch!/2` function in `Yex.Map` for improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->