### PR TITLE
implement Array.move_to

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ end
 | YMap: weak links                        | &#x2705; <br/> <small>(weak-links branch)</small> |                  &#x2705;                  |                  &#x274C;                  |
 | YArray: insert/delete                   |                     &#x2705;                      |                  &#x2705;                  |                  &#x2705;                  |
 | YArray & YText quotations               | &#x2705; <br/> <small>(weak links branch)</small> |                  &#x2705;                  |                  &#x2705;                  |
-| YArray: move                            |    &#x2705; <br/> <small>(move branch)</small>    |                  &#x2705;                  |                  &#x274C;                  |
+| YArray: move                            |    &#x2705; <br/> <small>(move branch)</small>    |                  &#x2705;                  |                  &#x2705;                  |
 | XML Element, Fragment and Text          |                     &#x2705;                      |                  &#x2705;                  |                  &#x2705;                  |
 | Sub-documents                           |                     &#x2705;                      |                  &#x2705;                  |                  &#x274C;                  |
 | Shared collections: observers           |                     &#x2705;                      |                  &#x2705;                  |                  &#x274C;                  |

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -49,6 +49,8 @@ defmodule Yex.Nif do
   def array_delete_range(_array, _cur_txn, _index, _length),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def array_move_to(_array, _cur_txn, _from, _to), do: :erlang.nif_error(:nif_not_loaded)
+
   def array_to_json(_array, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
 
   def map_set(_map, _cur_txn, _key, _value), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/shared_type/array.ex
+++ b/lib/shared_type/array.ex
@@ -66,6 +66,22 @@ defmodule Yex.Array do
     Yex.Nif.array_delete_range(array, cur_txn(array), index, length)
   end
 
+  @doc """
+  Moves element found at `source` index into `target` index position. Both indexes refer to a current state of the document.
+  ## Examples pushes a string then fetches it back
+      iex> doc = Yex.Doc.new()
+      iex> array = Yex.Doc.get_array(doc, "array")
+      iex> Yex.Array.push(array, Yex.ArrayPrelim.from([1, 2]))
+      iex> Yex.Array.push(array, Yex.ArrayPrelim.from([3, 4]))
+      iex> :ok = Yex.Array.move_to(array, 0, 2)
+      iex> Yex.Array.to_json(array)
+      [[3, 4], [1, 2]]
+  """
+  @spec move_to(t, integer(), integer()) :: :ok
+  def move_to(%__MODULE__{} = array, from, to) do
+    Yex.Nif.array_move_to(array, cur_txn(array), from, to)
+  end
+
   @deprecated "Rename to `fetch/2`"
   @spec get(t, integer()) :: {:ok, term()} | :error
   def get(array, index) do

--- a/native/yex/src/array.rs
+++ b/native/yex/src/array.rs
@@ -103,7 +103,28 @@ fn array_delete_range(
 ) -> NifResult<Atom> {
     array.mutably(env, current_transaction, |txn| {
         let array = array.get_ref(txn)?;
+        if index + length > array.len(txn) {
+            return Err(rustler::Error::Atom("error"));
+        }
         array.remove_range(txn, index, length);
+        Ok(atoms::ok())
+    })
+}
+#[rustler::nif]
+fn array_move_to(
+    env: Env<'_>,
+    array: NifArray,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+    from: u32,
+    to: u32,
+) -> NifResult<Atom> {
+    array.mutably(env, current_transaction, |txn| {
+        let array = array.get_ref(txn)?;
+        let len = array.len(txn);
+        if from >= len || to > len {
+            return Err(rustler::Error::Atom("error"));
+        }
+        array.move_to(txn, from, to);
         Ok(atoms::ok())
     })
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced the `move_to` function in the `Yex.Array` module for moving elements within an array.
	- Added `array_move_to` function in the NIF interface for enhanced array manipulation.
- **Bug Fixes**
	- Updated the feature parity table to reflect that the "YArray: move" functionality is now supported.
- **Tests**
	- Added new test cases to validate the functionality of the `move_to` function and monitor updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->