### PR TITLE
fix: When unobserve in shared_doc, remove awareness of the same origin

### DIFF
--- a/lib/protocols/shared_doc.ex
+++ b/lib/protocols/shared_doc.ex
@@ -33,7 +33,6 @@ defmodule Yex.Sync.SharedDoc do
   message mus be represented in the Yjs protocol default format.
   type supports sync and awareness.
   """
-  @deprecated "Use `process_message_v1/3` instead"
   def send_yjs_message(server, message) when is_binary(message) do
     process_message_v1(server, message, self())
     |> handle_process_message_result(server)
@@ -43,7 +42,6 @@ defmodule Yex.Sync.SharedDoc do
   Start the initial state exchange.
 
   """
-  @deprecated "Use `process_message_v1/3` instead"
   def start_sync(server, step1_message) do
     process_message_v1(server, step1_message, self())
     |> handle_process_message_result(server)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced state management for tracking clients based on their origin.
	- Enhanced handling of awareness updates for improved message processing.
	- Added new test cases for awareness updates and persistence behavior.

- **Bug Fixes**
	- Improved error handling to ensure smoother application flow.

- **Tests**
	- Restructured tests for observing and unobserving shared documents.
	- Added new test cases for verifying awareness behavior when unobserving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->