### PR TITLE
XmlElementPrelim allows attributes to be passed as a map

### DIFF
--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -166,10 +166,10 @@ defmodule Yex.XmlElementPrelim do
           children: [Yex.XmlElementPrelim.t() | Yex.XmlTextPrelim.t()]
         }
 
-  def new(tag, children) do
+  def new(tag, children, attributes \\ %{}) do
     %__MODULE__{
       tag: tag,
-      attributes: %{},
+      attributes: attributes,
       children: Enum.to_list(children)
     }
   end

--- a/native/yex/src/yinput.rs
+++ b/native/yex/src/yinput.rs
@@ -186,24 +186,9 @@ impl Prelim for NifYInput {
                 let text = TextRef::from(inner_ref);
                 text.apply_delta(txn, v.delta.0);
             }
-            NifYInput::XmlTextPrelim(v) => {
-                let text = XmlTextRef::from(inner_ref);
-                text.apply_delta(txn, v.delta.0);
-            }
-            NifYInput::XmlElementPrelim(v) => {
-                let element = XmlElementRef::from(inner_ref);
-
-                for value in v.children {
-                    element.push_back(txn, value);
-                }
-            }
-            NifYInput::XmlFragmentPrelim(v) => {
-                let element = XmlFragmentRef::from(inner_ref);
-
-                for value in v.children {
-                    element.push_back(txn, value);
-                }
-            }
+            NifYInput::XmlTextPrelim(v) => v.integrate(txn, inner_ref),
+            NifYInput::XmlElementPrelim(v) => v.integrate(txn, inner_ref),
+            NifYInput::XmlFragmentPrelim(v) => v.integrate(txn, inner_ref),
         }
     }
 }
@@ -239,24 +224,9 @@ impl Prelim for NifXmlIn {
 
     fn integrate(self, txn: &mut TransactionMut, inner_ref: BranchPtr) {
         match self {
-            NifXmlIn::Text(v) => {
-                let text = XmlTextRef::from(inner_ref);
-                text.apply_delta(txn, v.delta.0);
-            }
-            NifXmlIn::Element(v) => {
-                let element = XmlElementRef::from(inner_ref);
-
-                for value in v.children {
-                    element.push_back(txn, value);
-                }
-            }
-            NifXmlIn::Fragment(v) => {
-                let element = XmlFragmentRef::from(inner_ref);
-
-                for value in v.children {
-                    element.push_back(txn, value);
-                }
-            }
+            NifXmlIn::Text(v) => v.integrate(txn, inner_ref),
+            NifXmlIn::Element(v) => v.integrate(txn, inner_ref),
+            NifXmlIn::Fragment(v) => v.integrate(txn, inner_ref),
         }
     }
 }

--- a/test/shared_type/xml_element_test.exs
+++ b/test/shared_type/xml_element_test.exs
@@ -167,5 +167,21 @@ defmodule YexXmlElementTest do
       assert "<div><div></div><div></div><span>text</span><div></div>textdiv</div>" ==
                XmlFragment.to_string(xml_fragment)
     end
+
+    test "XmlElementPrelim.new with attribute", %{xml_fragment: xml_fragment} do
+      XmlFragment.push(
+        xml_fragment,
+        XmlElementPrelim.new(
+          "div",
+          [
+            XmlTextPrelim.from("text")
+          ],
+          %{"href" => "http://example.com"}
+        )
+      )
+
+      assert "<div href=\"http://example.com\">text</div>" ==
+               XmlFragment.to_string(xml_fragment)
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can now initialize XML elements with optional attributes using the updated `new` method.

- **Bug Fixes**
  - Improved integration logic for XML-related structures, enhancing maintainability and reducing redundancy.

- **Tests**
  - Added a new test case to validate the creation of XML elements with attributes, ensuring correct output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->