### PR TITLE
feat: sticky index

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -127,6 +127,12 @@ defmodule Yex.Nif do
   def shared_type_observe_deep(_map, _cur_txn, _pid, _ref, _metadata),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def sticky_index_new(_shared_type, _cur_txn, _index, _assoc),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def sticky_index_get_offset(_sticky_index, _cur_txn),
+    do: :erlang.nif_error(:nif_not_loaded)
+
   def encode_state_vector_v1(_doc, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def encode_state_as_update_v1(_doc, _cur_txn, _diff), do: :erlang.nif_error(:nif_not_loaded)
   def apply_update_v1(_doc, _cur_txn, _update), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/sticky_index.ex
+++ b/lib/sticky_index.ex
@@ -1,6 +1,32 @@
 defmodule Yex.StickyIndex do
   @moduledoc """
-  A shareable Array-like type that supports efficient insert/delete of elements at any position.
+  A sticky index is based on the Yjs model and is not affected by document changes. E.g. If you place a sticky index before a certain character, it will always point to this character. If you place a sticky index at the end of a type, it will always point to the end of the type.
+  A numeric position is often unsuited for user selections, because it does not change when content is inserted before or after.
+
+    `Insert(0, 'x')('a.bc') = 'xa.bc' Where . is the relative position.`
+
+  ## Examples
+    iex> alias Yex.{StickyIndex, Doc, Text}
+    iex> doc = Doc.new()
+    iex> txt = Doc.get_text(doc, "text")
+    iex> Doc.transaction(doc, fn ->
+    ...>  Text.insert(txt, 0, "abc")
+    ...>  #  => 'abc'
+    ...>  # create position tracker (marked as . in the comments)
+    ...>  pos = StickyIndex.new(txt, 2, :after)
+    ...>  # => 'ab.c'
+    ...>
+    ...>  # modify text
+    ...>  Text.insert(txt, 1, "def")
+    ...>  # => 'adefb.c'
+    ...>  Text.delete(txt, 4, 1)
+    ...>  # => 'adef.c'
+    ...>
+    ...>  # get current offset index within the containing collection
+    ...>  {:ok, a} = StickyIndex.get_offset(pos)
+    ...>  # => 4
+    ...>  assert a.index == 4
+    ...> end)
   """
   defstruct [
     :reference,
@@ -22,7 +48,6 @@ defmodule Yex.StickyIndex do
   def new(shared_type, index, assoc) do
     Yex.Nif.sticky_index_new(shared_type, cur_txn(shared_type), index, assoc)
   end
-
 
   @spec get_offset(t) :: {:ok, %{index: integer(), assoc: :before | :after}} | :error
   def get_offset(%__MODULE__{} = sticky_index) do

--- a/lib/sticky_index.ex
+++ b/lib/sticky_index.ex
@@ -1,0 +1,34 @@
+defmodule Yex.StickyIndex do
+  @moduledoc """
+  A shareable Array-like type that supports efficient insert/delete of elements at any position.
+  """
+  defstruct [
+    :reference,
+    :assoc
+  ]
+
+  @type t :: %__MODULE__{
+          reference: reference(),
+          assoc: :before | :after
+        }
+
+  @type shared_type ::
+          %Yex.Array{}
+          | %Yex.Text{}
+          | %Yex.XmlElement{}
+          | %Yex.XmlText{}
+          | %Yex.XmlFragment{}
+  @spec new(shared_type, integer(), :before | :after) :: t
+  def new(shared_type, index, assoc) do
+    Yex.Nif.sticky_index_new(shared_type, cur_txn(shared_type), index, assoc)
+  end
+
+  @spec get_offset(t) :: {:ok, integer()} | :error
+  def get_offset(%__MODULE__{} = sticky_index) do
+    Yex.Nif.sticky_index_get_offset(sticky_index, cur_txn(sticky_index))
+  end
+
+  defp cur_txn(%{doc: doc_ref}) do
+    Process.get(doc_ref, nil)
+  end
+end

--- a/lib/sticky_index.ex
+++ b/lib/sticky_index.ex
@@ -23,7 +23,8 @@ defmodule Yex.StickyIndex do
     Yex.Nif.sticky_index_new(shared_type, cur_txn(shared_type), index, assoc)
   end
 
-  @spec get_offset(t) :: {:ok, integer()} | :error
+
+  @spec get_offset(t) :: {:ok, %{index: integer(), assoc: :before | :after}} | :error
   def get_offset(%__MODULE__{} = sticky_index) do
     Yex.Nif.sticky_index_get_offset(sticky_index, cur_txn(sticky_index))
   end

--- a/lib/sticky_index.ex
+++ b/lib/sticky_index.ex
@@ -29,11 +29,13 @@ defmodule Yex.StickyIndex do
     ...> end)
   """
   defstruct [
+    :doc,
     :reference,
     :assoc
   ]
 
   @type t :: %__MODULE__{
+          doc: reference(),
           reference: reference(),
           assoc: :before | :after
         }

--- a/native/yex/src/lib.rs
+++ b/native/yex/src/lib.rs
@@ -7,6 +7,7 @@ mod error;
 mod event;
 mod map;
 mod shared_type;
+mod sticky_index;
 mod subscription;
 mod sync;
 mod term_box;

--- a/native/yex/src/shared_type.rs
+++ b/native/yex/src/shared_type.rs
@@ -28,9 +28,7 @@ impl<'de, 'a: 'de, T> Encoder for SharedTypeId<T> {
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
         let mut s = flexbuffers::FlexbufferSerializer::new();
 
-        if let Err(err) = self.hook.serialize(&mut s) {
-            return (atoms::error(), err.to_string()).encode(env);
-        }
+        self.hook.serialize(&mut s).expect("encode failed");
         SliceIntoBinary::new(s.view()).encode(env)
     }
 }

--- a/native/yex/src/sticky_index.rs
+++ b/native/yex/src/sticky_index.rs
@@ -1,0 +1,181 @@
+use rustler::{Atom, Decoder, Encoder, Env, NifResult, NifStruct, NifUnitEnum, ResourceArc, Term};
+use serde::{Deserialize as _, Serialize as _};
+use yrs::{Assoc, IndexedSequence as _, StickyIndex};
+
+use crate::{
+    atoms,
+    doc::{DocResource, TransactionResource},
+    shared_type::NifSharedType,
+    wrap::SliceIntoBinary,
+    yinput::NifSharedTypeInput,
+};
+
+pub struct StickyIndexRef(pub StickyIndex);
+impl StickyIndexRef {
+    pub fn new(v: StickyIndex) -> Self {
+        Self(v)
+    }
+}
+
+impl<'de, 'a: 'de> Encoder for StickyIndexRef {
+    fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
+        let mut s = flexbuffers::FlexbufferSerializer::new();
+
+        if let Err(err) = self.0.serialize(&mut s) {
+            return (atoms::error(), err.to_string()).encode(env);
+        }
+        SliceIntoBinary::new(s.view()).encode(env)
+    }
+}
+impl<'a> Decoder<'a> for StickyIndexRef {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let bin = term.decode_as_binary()?;
+        let r =
+            flexbuffers::Reader::get_root(bin.as_slice()).map_err(|_e| rustler::Error::BadArg)?;
+        let hook = StickyIndex::deserialize(r).map_err(|_e| rustler::Error::BadArg)?;
+        Ok(StickyIndexRef::new(hook))
+    }
+}
+
+#[derive(NifStruct)]
+#[module = "Yex.StickyIndex"]
+pub struct NifStickyIndex {
+    doc: ResourceArc<DocResource>,
+    reference: StickyIndexRef,
+    assoc: NifAssoc,
+}
+#[derive(NifUnitEnum)]
+enum NifAssoc {
+    After,
+    Before,
+}
+
+impl From<Assoc> for NifAssoc {
+    fn from(v: Assoc) -> NifAssoc {
+        match v {
+            Assoc::After => NifAssoc::After,
+            Assoc::Before => NifAssoc::Before,
+        }
+    }
+}
+
+impl From<&NifAssoc> for Assoc {
+    fn from(v: &NifAssoc) -> Assoc {
+        match v {
+            NifAssoc::After => Assoc::After,
+            NifAssoc::Before => Assoc::Before,
+        }
+    }
+}
+
+#[rustler::nif]
+fn sticky_index_new(
+    env: Env<'_>,
+    shared_type: NifSharedTypeInput,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+    index: u32,
+    assoc: NifAssoc,
+) -> NifResult<NifStickyIndex> {
+    match shared_type {
+        NifSharedTypeInput::Array(array) => array.mutably(env, current_transaction, |txn| {
+            let doc = array.doc().clone();
+            let array = array.get_ref(txn)?;
+            let sticky_index = array
+                .sticky_index(txn, index, (&assoc).into())
+                .ok_or(rustler::Error::BadArg)?;
+            let sticky_index = NifStickyIndex {
+                doc: doc,
+                reference: StickyIndexRef::new(sticky_index),
+                assoc,
+            };
+            Ok(sticky_index)
+        }),
+        NifSharedTypeInput::Text(text) => text.mutably(env, current_transaction, |txn| {
+            let doc = text.doc().clone();
+            let text = text.get_ref(txn)?;
+            let sticky_index = text
+                .sticky_index(txn, index, (&assoc).into())
+                .ok_or(rustler::Error::BadArg)?;
+            let sticky_index = NifStickyIndex {
+                doc: doc,
+                reference: StickyIndexRef::new(sticky_index),
+                assoc,
+            };
+            Ok(sticky_index)
+        }),
+        NifSharedTypeInput::XmlText(xml_text) => {
+            xml_text.mutably(env, current_transaction, |txn| {
+                let doc = xml_text.doc().clone();
+                let xml_text = xml_text.get_ref(txn)?;
+                let sticky_index = xml_text
+                    .sticky_index(txn, index, (&assoc).into())
+                    .ok_or(rustler::Error::BadArg)?;
+                let sticky_index = NifStickyIndex {
+                    doc: doc,
+                    reference: StickyIndexRef::new(sticky_index),
+                    assoc: assoc,
+                };
+                Ok(sticky_index)
+            })
+        }
+        NifSharedTypeInput::XmlFragment(xml_fragment) => {
+            xml_fragment.mutably(env, current_transaction, |txn| {
+                let doc = xml_fragment.doc().clone();
+                let xml_fragment = xml_fragment.get_ref(txn)?;
+                let sticky_index = xml_fragment
+                    .sticky_index(txn, index, (&assoc).into())
+                    .ok_or(rustler::Error::BadArg)?;
+                let sticky_index = NifStickyIndex {
+                    doc: doc,
+                    reference: StickyIndexRef::new(sticky_index),
+                    assoc,
+                };
+                Ok(sticky_index)
+            })
+        }
+        NifSharedTypeInput::XmlElement(xml_element) => {
+            xml_element.mutably(env, current_transaction, |txn| {
+                let doc = xml_element.doc().clone();
+                let xml_element = xml_element.get_ref(txn)?;
+                let sticky_index = xml_element
+                    .sticky_index(txn, index, (&assoc).into())
+                    .ok_or(rustler::Error::BadArg)?;
+                let sticky_index = NifStickyIndex {
+                    doc: doc,
+                    reference: StickyIndexRef::new(sticky_index),
+                    assoc,
+                };
+                Ok(sticky_index)
+            })
+        }
+        _ => Err(rustler::Error::BadArg),
+    }
+}
+
+#[derive(rustler::NifMap)]
+struct NifOffset {
+    pub index: u32,
+    pub assoc: NifAssoc,
+}
+
+#[rustler::nif]
+fn sticky_index_get_offset(
+    sticky_index: NifStickyIndex,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+) -> NifResult<(Atom, NifOffset)> {
+    let doc = sticky_index.doc.clone();
+
+    doc.readonly(current_transaction, |txn| {
+        let sticky_index = sticky_index.reference.0;
+        match sticky_index.get_offset(txn) {
+            Some(offset) => Ok((
+                atoms::ok(),
+                NifOffset {
+                    index: offset.index,
+                    assoc: offset.assoc.into(),
+                },
+            )),
+            None => Err(rustler::Error::Atom("error")),
+        }
+    })
+}

--- a/native/yex/src/sticky_index.rs
+++ b/native/yex/src/sticky_index.rs
@@ -21,9 +21,7 @@ impl<'de, 'a: 'de> Encoder for StickyIndexRef {
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
         let mut s = flexbuffers::FlexbufferSerializer::new();
 
-        if let Err(err) = self.0.serialize(&mut s) {
-            return (atoms::error(), err.to_string()).encode(env);
-        }
+        self.0.serialize(&mut s).expect("encode failed");
         SliceIntoBinary::new(s.view()).encode(env)
     }
 }

--- a/test/sticky_index_test.exs
+++ b/test/sticky_index_test.exs
@@ -1,6 +1,7 @@
 defmodule Yex.StickyIndexTest do
   use ExUnit.Case
   alias Yex.{StickyIndex, Doc, Text}
+  doctest StickyIndex
 
   test "new" do
     doc = Doc.new()

--- a/test/sticky_index_test.exs
+++ b/test/sticky_index_test.exs
@@ -1,0 +1,29 @@
+defmodule Yex.StickyIndexTest do
+  use ExUnit.Case
+  alias Yex.{StickyIndex, Doc, Text}
+
+  test "new" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    Doc.transaction(doc, fn ->
+      Text.insert(txt, 0, "abc")
+      #  => 'abc'
+      # create position tracker (marked as . in the comments)
+      pos = StickyIndex.new(txt, 2, :after)
+      # => 'ab.c'
+
+      # modify text
+      Text.insert(txt, 1, "def")
+      # => 'adefb.c'
+      Text.delete(txt, 4, 1)
+      # => 'adef.c'
+
+      # get current offset index within the containing collection
+      {:ok, a} = StickyIndex.get_offset(pos)
+      # => 4
+      assert a.index == 4
+      assert a.assoc == :after
+    end)
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new module for managing a `StickyIndex`, allowing persistent positioning of elements in documents.
	- Added functions to create a new `StickyIndex` and retrieve its offset.

- **Bug Fixes**
	- Enhanced error handling for sticky index operations.

- **Tests**
	- Added a test module to verify the functionality of the `StickyIndex` with text documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->