### PR TITLE
Use try_ for transaction acquisition

### DIFF
--- a/lib/doc.ex
+++ b/lib/doc.ex
@@ -1,4 +1,13 @@
 defmodule Yex.Doc do
+  @moduledoc """
+  Document module.
+
+  ### Important
+    It is not recommended to perform operations on a single document from multiple processes simultaneously.
+    If blocked by a transaction, the Beam scheduler threads may potentially deadlock.
+    This limitation is due to the underlying yrs and beam specifications and may be resolved in the future.
+  """
+
   defmodule Options do
     @moduledoc """
     Document options.

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -181,9 +181,3 @@ defmodule Yex.Nif do
   def undo_manager_stop_capturing(_undo_manager), do: :erlang.nif_error(:nif_not_loaded)
   def undo_manager_clear(_undo_manager), do: :erlang.nif_error(:nif_not_loaded)
 end
-
-defmodule Yex.Nif.Util do
-  @moduledoc false
-  def unwrap_ok_tuple({:ok, {}}), do: :ok
-  def unwrap_ok_tuple(other), do: other
-end

--- a/lib/protocols/awareness.ex
+++ b/lib/protocols/awareness.ex
@@ -167,7 +167,7 @@ defmodule Yex.Awareness do
   """
   @spec apply_update(t, binary(), origin :: term() | nil) :: :ok
   def apply_update(awareness, update, origin \\ nil) do
-    Yex.Nif.awareness_apply_update_v1(awareness, update, origin) |> Yex.Nif.Util.unwrap_ok_tuple()
+    Yex.Nif.awareness_apply_update_v1(awareness, update, origin)
   end
 
   @doc """

--- a/lib/y_ex.ex
+++ b/lib/y_ex.ex
@@ -101,12 +101,12 @@ defmodule Yex do
 
   @spec apply_update_v1(Yex.Doc.t(), binary()) :: :ok | {:error, term()}
   def apply_update_v1(%Yex.Doc{} = doc, update) do
-    Yex.Nif.apply_update_v1(doc, cur_txn(doc), update) |> Yex.Nif.Util.unwrap_ok_tuple()
+    Yex.Nif.apply_update_v1(doc, cur_txn(doc), update)
   end
 
   @spec apply_update_v2(Yex.Doc.t(), binary()) :: :ok | {:error, term()}
   def apply_update_v2(%Yex.Doc{} = doc, update) do
-    Yex.Nif.apply_update_v2(doc, cur_txn(doc), update) |> Yex.Nif.Util.unwrap_ok_tuple()
+    Yex.Nif.apply_update_v2(doc, cur_txn(doc), update)
   end
 
   defp cur_txn(%Yex.Doc{reference: doc_ref}) do

--- a/native/yex/src/array.rs
+++ b/native/yex/src/array.rs
@@ -4,9 +4,10 @@ use yrs::*;
 
 use crate::{
     atoms,
-    doc::{DocResource, TransactionResource},
+    doc::DocResource,
     event::{NifArrayEvent, NifSharedTypeDeepObservable, NifSharedTypeObservable},
     shared_type::{NifSharedType, SharedTypeId},
+    transaction::TransactionResource,
     yinput::NifYInput,
     youtput::NifYOut,
     NifAny,

--- a/native/yex/src/doc.rs
+++ b/native/yex/src/doc.rs
@@ -253,8 +253,8 @@ fn doc_begin_transaction(
 
         Ok(TransactionResource(RefCell::new(Some(txn))).into())
     } else {
-        let txn: TransactionMut = yrs::Transact::try_transact_mut(&doc.reference.doc)
-        .map_err(Error::from)?;
+        let txn: TransactionMut =
+            yrs::Transact::try_transact_mut(&doc.reference.doc).map_err(Error::from)?;
         let txn: TransactionMut<'static> = unsafe { std::mem::transmute(txn) };
         Ok(TransactionResource(RefCell::new(Some(txn))).into())
     }

--- a/native/yex/src/doc.rs
+++ b/native/yex/src/doc.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use crate::error::Error;
 use crate::subscription::SubscriptionResource;
 use crate::term_box::TermBox;
+use crate::transaction::{ReadTransaction, TransactionResource};
 use crate::utils::{origin_to_term, term_to_origin_binary};
 use crate::wrap::SliceIntoBinary;
 use crate::xml::NifXmlFragment;
@@ -28,19 +29,22 @@ impl DocInner {
         env: Env<'_>,
         current_transaction: Option<ResourceArc<TransactionResource>>,
         f: F,
-    ) -> T
+    ) -> NifResult<T>
     where
-        F: FnOnce(&mut TransactionMut<'_>) -> T,
+        F: FnOnce(&mut TransactionMut<'_>) -> NifResult<T>,
     {
         ENV.set(&mut env.clone(), || {
             if let Some(txn) = current_transaction {
                 if let Some(txn) = txn.0.borrow_mut().as_mut() {
                     f(txn)
                 } else {
-                    f(&mut yrs::Transact::transact_mut(&self.doc))
+                    let txn =
+                        &mut yrs::Transact::try_transact_mut(&self.doc).map_err(Error::from)?;
+                    f(txn)
                 }
             } else {
-                f(&mut yrs::Transact::transact_mut(&self.doc))
+                let txn = &mut yrs::Transact::try_transact_mut(&self.doc).map_err(Error::from)?;
+                f(txn)
             }
         })
     }
@@ -49,9 +53,9 @@ impl DocInner {
         &self,
         current_transaction: Option<ResourceArc<TransactionResource>>,
         f: F,
-    ) -> T
+    ) -> NifResult<T>
     where
-        F: FnOnce(&ReadTransaction) -> T,
+        F: FnOnce(&ReadTransaction) -> NifResult<T>,
     {
         // TODO:
         if let Some(txn) = current_transaction {
@@ -59,42 +63,20 @@ impl DocInner {
                 txn.store();
                 f(&ReadTransaction::ReadWrite(txn))
             } else {
-                f(&ReadTransaction::ReadOnly(&yrs::Transact::transact(
-                    &self.doc,
-                )))
+                let txn: &Transaction<'_> =
+                    &yrs::Transact::try_transact(&self.doc).map_err(Error::from)?;
+                f(&ReadTransaction::ReadOnly(txn))
             }
         } else {
-            f(&ReadTransaction::ReadOnly(&yrs::Transact::transact(
-                &self.doc,
-            )))
-        }
-    }
-}
-
-pub enum ReadTransaction<'a, 'doc> {
-    ReadOnly(&'a yrs::Transaction<'doc>),
-    ReadWrite(&'a yrs::TransactionMut<'doc>),
-}
-
-impl ReadTxn for ReadTransaction<'_, '_> {
-    fn store(&self) -> &Store {
-        match &self {
-            ReadTransaction::ReadOnly(txn) => txn.store(),
-            ReadTransaction::ReadWrite(txn) => txn.store(),
+            let txn: &Transaction<'_> =
+                &yrs::Transact::try_transact(&self.doc).map_err(Error::from)?;
+            f(&ReadTransaction::ReadOnly(txn))
         }
     }
 }
 
 #[rustler::resource_impl]
 impl rustler::Resource for DocResource {}
-
-pub struct TransactionResource(pub RefCell<Option<TransactionMut<'static>>>);
-
-unsafe impl Send for TransactionResource {}
-unsafe impl Sync for TransactionResource {}
-
-#[rustler::resource_impl]
-impl rustler::Resource for TransactionResource {}
 
 #[derive(NifUnitEnum)]
 pub enum NifOffsetKind {
@@ -259,17 +241,22 @@ fn doc_get_or_insert_xml_fragment(env: Env<'_>, doc: NifDoc, name: &str) -> NifX
 }
 
 #[rustler::nif]
-fn doc_begin_transaction(doc: NifDoc, origin: Term<'_>) -> ResourceArc<TransactionResource> {
+fn doc_begin_transaction(
+    doc: NifDoc,
+    origin: Term<'_>,
+) -> NifResult<ResourceArc<TransactionResource>> {
     if let Some(origin) = term_to_origin_binary(origin) {
         let txn: TransactionMut =
-            yrs::Transact::transact_mut_with(&doc.reference.doc, origin.as_slice());
+            yrs::Transact::try_transact_mut_with(&doc.reference.doc, origin.as_slice())
+                .map_err(Error::from)?;
         let txn: TransactionMut<'static> = unsafe { std::mem::transmute(txn) };
 
-        TransactionResource(RefCell::new(Some(txn))).into()
+        Ok(TransactionResource(RefCell::new(Some(txn))).into())
     } else {
-        let txn: TransactionMut = yrs::Transact::transact_mut(&doc.reference.doc);
+        let txn: TransactionMut = yrs::Transact::try_transact_mut(&doc.reference.doc)
+        .map_err(Error::from)?;
         let txn: TransactionMut<'static> = unsafe { std::mem::transmute(txn) };
-        TransactionResource(RefCell::new(Some(txn))).into()
+        Ok(TransactionResource(RefCell::new(Some(txn))).into())
     }
 }
 
@@ -353,7 +340,9 @@ fn apply_update_v2(
     current_transaction: Option<ResourceArc<TransactionResource>>,
     update: Binary,
 ) -> NifResult<Atom> {
-    let update = Update::decode_v2(update.as_slice()).map_err(Error::from)?;
+    let update = Update::decode_v2(update.as_slice()).map_err(|e| {
+        rustler::Error::Term(Box::new((atoms::encoding_exception(), e.to_string())))
+    })?;
 
     doc.reference.mutably(env, current_transaction, |txn| {
         txn.apply_update(update)
@@ -398,9 +387,9 @@ fn encode_state_vector_v2(
     doc: NifDoc,
     current_transaction: Option<ResourceArc<TransactionResource>>,
 ) -> NifResult<Term<'_>> {
-    let vec = doc
-        .reference
-        .readonly(current_transaction, |txn| txn.state_vector().encode_v2());
+    let vec = doc.reference.readonly(current_transaction, |txn| {
+        Ok(txn.state_vector().encode_v2())
+    })?;
     Ok((atoms::ok(), SliceIntoBinary::new(vec.as_slice())).encode(env))
 }
 #[rustler::nif]
@@ -416,7 +405,9 @@ fn encode_state_as_update_v2<'a>(
         StateVector::default()
     };
 
-    doc.reference
-        .readonly(current_transaction, |txn| Ok(txn.encode_diff_v2(&sv)))
-        .map(|vec| (atoms::ok(), SliceIntoBinary::new(vec.as_slice())).encode(env))
+    let vec = doc
+        .reference
+        .readonly(current_transaction, |txn| Ok(txn.encode_diff_v2(&sv)))?;
+
+    Ok((atoms::ok(), SliceIntoBinary::new(vec.as_slice())).encode(env))
 }

--- a/native/yex/src/event.rs
+++ b/native/yex/src/event.rs
@@ -16,21 +16,10 @@ use yrs::{
 };
 
 use crate::{
-    any::NifAny,
-    array::NifArray,
-    atoms,
-    doc::{DocResource, TransactionResource},
-    map::NifMap,
-    shared_type::NifSharedType,
-    subscription::SubscriptionResource,
-    term_box::TermBox,
-    text::NifText,
-    utils::origin_to_term,
-    wrap::NifWrap,
-    xml::NifXmlText,
-    yinput::NifSharedTypeInput,
-    youtput::NifYOut,
-    ENV,
+    any::NifAny, array::NifArray, atoms, doc::DocResource, map::NifMap, shared_type::NifSharedType,
+    subscription::SubscriptionResource, term_box::TermBox, text::NifText,
+    transaction::TransactionResource, utils::origin_to_term, wrap::NifWrap, xml::NifXmlText,
+    yinput::NifSharedTypeInput, youtput::NifYOut, ENV,
 };
 
 #[derive(NifUntaggedEnum)]

--- a/native/yex/src/lib.rs
+++ b/native/yex/src/lib.rs
@@ -12,6 +12,7 @@ mod subscription;
 mod sync;
 mod term_box;
 mod text;
+mod transaction;
 mod undo;
 mod utils;
 mod wrap;

--- a/native/yex/src/map.rs
+++ b/native/yex/src/map.rs
@@ -1,8 +1,8 @@
 use crate::atoms;
-use crate::doc::TransactionResource;
 use crate::event::{NifMapEvent, NifSharedTypeDeepObservable, NifSharedTypeObservable};
 use crate::shared_type::NifSharedType;
 use crate::shared_type::SharedTypeId;
+use crate::transaction::TransactionResource;
 use crate::{doc::DocResource, yinput::NifYInput, youtput::NifYOut, NifAny};
 use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
 use std::collections::HashMap;

--- a/native/yex/src/shared_type.rs
+++ b/native/yex/src/shared_type.rs
@@ -4,7 +4,8 @@ use std::ops::Deref;
 use yrs::{Hook, ReadTxn, SharedRef, TransactionMut};
 
 use crate::{
-    doc::{DocResource, ReadTransaction, TransactionResource},
+    doc::DocResource,
+    transaction::{ReadTransaction, TransactionResource},
     wrap::SliceIntoBinary,
 };
 
@@ -63,9 +64,9 @@ where
         env: Env<'_>,
         current_transaction: Option<ResourceArc<TransactionResource>>,
         f: F,
-    ) -> T
+    ) -> NifResult<T>
     where
-        F: FnOnce(&mut TransactionMut<'_>) -> T,
+        F: FnOnce(&mut TransactionMut<'_>) -> NifResult<T>,
     {
         self.doc().mutably(env, current_transaction, f)
     }
@@ -74,9 +75,9 @@ where
         &self,
         current_transaction: Option<ResourceArc<TransactionResource>>,
         f: F,
-    ) -> T
+    ) -> NifResult<T>
     where
-        F: FnOnce(&ReadTransaction) -> T,
+        F: FnOnce(&ReadTransaction) -> NifResult<T>,
     {
         self.doc().readonly(current_transaction, f)
     }

--- a/native/yex/src/sticky_index.rs
+++ b/native/yex/src/sticky_index.rs
@@ -3,11 +3,8 @@ use serde::{Deserialize as _, Serialize as _};
 use yrs::{Assoc, IndexedSequence, StickyIndex};
 
 use crate::{
-    atoms,
-    doc::{DocResource, TransactionResource},
-    shared_type::NifSharedType,
-    wrap::SliceIntoBinary,
-    yinput::NifSharedTypeInput,
+    atoms, doc::DocResource, shared_type::NifSharedType, transaction::TransactionResource,
+    wrap::SliceIntoBinary, yinput::NifSharedTypeInput,
 };
 
 pub struct StickyIndexRef(pub StickyIndex);

--- a/native/yex/src/text.rs
+++ b/native/yex/src/text.rs
@@ -7,9 +7,10 @@ use yrs::*;
 use crate::{
     any::NifAttr,
     atoms,
-    doc::{DocResource, TransactionResource},
+    doc::DocResource,
     event::{NifSharedTypeDeepObservable, NifSharedTypeObservable, NifTextEvent},
     shared_type::{NifSharedType, SharedTypeId},
+    transaction::TransactionResource,
     yinput::NifYInputDelta,
     youtput::NifYOut,
 };

--- a/native/yex/src/transaction.rs
+++ b/native/yex/src/transaction.rs
@@ -1,0 +1,24 @@
+use std::cell::RefCell;
+use yrs::{ReadTxn, Store, Transaction, TransactionMut};
+
+pub struct TransactionResource(pub RefCell<Option<TransactionMut<'static>>>);
+
+unsafe impl Send for TransactionResource {}
+unsafe impl Sync for TransactionResource {}
+
+#[rustler::resource_impl]
+impl rustler::Resource for TransactionResource {}
+
+pub enum ReadTransaction<'a, 'doc> {
+    ReadOnly(&'a Transaction<'doc>),
+    ReadWrite(&'a TransactionMut<'doc>),
+}
+
+impl ReadTxn for ReadTransaction<'_, '_> {
+    fn store(&self) -> &Store {
+        match &self {
+            ReadTransaction::ReadOnly(txn) => txn.store(),
+            ReadTransaction::ReadWrite(txn) => txn.store(),
+        }
+    }
+}

--- a/native/yex/src/xml.rs
+++ b/native/yex/src/xml.rs
@@ -9,10 +9,11 @@ use yrs::{
 use crate::{
     any::NifAttr,
     atoms,
-    doc::{DocResource, TransactionResource},
+    doc::DocResource,
     event::{NifSharedTypeDeepObservable, NifSharedTypeObservable, NifXmlEvent, NifXmlTextEvent},
     shared_type::{NifSharedType, SharedTypeId},
     text::encode_diffs,
+    transaction::TransactionResource,
     yinput::{NifXmlIn, NifYInputDelta},
     youtput::NifYOut,
     ENV,


### PR DESCRIPTION
Returns transaction_acq_error instead of blocking.

This is because blocking within the NIF function can lead to a potential deadlock. 
However, there are other processes that block to acquire the transaction (for example, yrs::Doc::get_or_insert_xxxx used in Doc.get_xxx), so this does not solve the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added module documentation for `Yex.Doc` explaining potential concurrent operation limitations.

- **Refactor**
	- Removed `Yex.Nif.Util` module and related utility functions.
	- Updated error handling in multiple modules to improve transaction and update management.
	- Reorganized import statements across multiple Rust source files.

- **New Features**
	- Introduced new `TransactionResource` struct for managing transactions.
	- Added `NifYMapChange` struct for enhanced map event representation.
	- Added a new `transaction` module to expand transaction handling capabilities.

- **Bug Fixes**
	- Improved error propagation in transaction-related methods.
	- Enhanced transaction handling across various data type operations (text, XML, map, array).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->