### PR TITLE
refactor: doc structure

### DIFF
--- a/lib/shared_type/array.ex
+++ b/lib/shared_type/array.ex
@@ -8,7 +8,7 @@ defmodule Yex.Array do
   ]
 
   @type t :: %__MODULE__{
-          doc: reference(),
+          doc: Yex.Doc.t(),
           reference: reference()
         }
 
@@ -158,7 +158,7 @@ defmodule Yex.Array do
     Yex.Nif.array_to_json(array, cur_txn(array))
   end
 
-  defp cur_txn(%__MODULE__{doc: doc_ref}) do
+  defp cur_txn(%{doc: %Yex.Doc{reference: doc_ref}}) do
     Process.get(doc_ref, nil)
   end
 end

--- a/lib/shared_type/map.ex
+++ b/lib/shared_type/map.ex
@@ -8,7 +8,7 @@ defmodule Yex.Map do
   ]
 
   @type t :: %__MODULE__{
-          doc: reference(),
+          doc: Yex.Doc.t(),
           reference: reference()
         }
 
@@ -115,7 +115,7 @@ defmodule Yex.Map do
     Yex.Nif.map_to_json(map, cur_txn(map))
   end
 
-  defp cur_txn(%__MODULE__{doc: doc_ref}) do
+  defp cur_txn(%{doc: %Yex.Doc{reference: doc_ref}}) do
     Process.get(doc_ref, nil)
   end
 end

--- a/lib/shared_type/text.ex
+++ b/lib/shared_type/text.ex
@@ -12,7 +12,7 @@ defmodule Yex.Text do
           | [%{delete: integer()}]
           | [%{:retain => integer(), optional(:attributes) => map()}]
   @type t :: %__MODULE__{
-          doc: reference(),
+          doc: Yex.Doc.t(),
           reference: reference()
         }
 
@@ -80,7 +80,7 @@ defmodule Yex.Text do
     Yex.Nif.text_to_delta(text, cur_txn(text))
   end
 
-  defp cur_txn(%__MODULE__{doc: doc_ref}) do
+  defp cur_txn(%{doc: %Yex.Doc{reference: doc_ref}}) do
     Process.get(doc_ref, nil)
   end
 end

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -12,7 +12,7 @@ defmodule Yex.XmlElement do
   ]
 
   @type t :: %__MODULE__{
-          doc: reference(),
+          doc: Yex.Doc.t(),
           reference: reference()
         }
 
@@ -141,7 +141,7 @@ defmodule Yex.XmlElement do
     Yex.Nif.xml_element_to_string(xml_element, cur_txn(xml_element))
   end
 
-  defp cur_txn(%__MODULE__{doc: doc_ref}) do
+  defp cur_txn(%{doc: %Yex.Doc{reference: doc_ref}}) do
     Process.get(doc_ref, nil)
   end
 end

--- a/lib/shared_type/xml_fragment.ex
+++ b/lib/shared_type/xml_fragment.ex
@@ -12,7 +12,7 @@ defmodule Yex.XmlFragment do
   ]
 
   @type t :: %__MODULE__{
-          doc: reference(),
+          doc: Yex.Doc.t(),
           reference: reference()
         }
 
@@ -99,7 +99,7 @@ defmodule Yex.XmlFragment do
     Yex.Nif.xml_fragment_to_string(xml_fragment, cur_txn(xml_fragment))
   end
 
-  defp cur_txn(%__MODULE__{doc: doc_ref}) do
+  defp cur_txn(%{doc: %Yex.Doc{reference: doc_ref}}) do
     Process.get(doc_ref, nil)
   end
 end

--- a/lib/shared_type/xml_text.ex
+++ b/lib/shared_type/xml_text.ex
@@ -11,7 +11,7 @@ defmodule Yex.XmlText do
   ]
 
   @type t :: %__MODULE__{
-          doc: reference(),
+          doc: Yex.Doc.t(),
           reference: reference()
         }
 
@@ -82,7 +82,7 @@ defmodule Yex.XmlText do
     Yex.Nif.xml_text_parent(xml_text, cur_txn(xml_text))
   end
 
-  defp cur_txn(%__MODULE__{doc: doc_ref}) do
+  defp cur_txn(%{doc: %Yex.Doc{reference: doc_ref}}) do
     Process.get(doc_ref, nil)
   end
 end

--- a/lib/sticky_index.ex
+++ b/lib/sticky_index.ex
@@ -35,7 +35,7 @@ defmodule Yex.StickyIndex do
   ]
 
   @type t :: %__MODULE__{
-          doc: reference(),
+          doc: Yex.Doc.t(),
           reference: reference(),
           assoc: :before | :after
         }
@@ -56,7 +56,7 @@ defmodule Yex.StickyIndex do
     Yex.Nif.sticky_index_get_offset(sticky_index, cur_txn(sticky_index))
   end
 
-  defp cur_txn(%{doc: doc_ref}) do
+  defp cur_txn(%{doc: %Yex.Doc{reference: doc_ref}}) do
     Process.get(doc_ref, nil)
   end
 end

--- a/native/yex/src/array.rs
+++ b/native/yex/src/array.rs
@@ -4,7 +4,7 @@ use yrs::*;
 
 use crate::{
     atoms,
-    doc::DocResource,
+    doc::NifDoc,
     event::{NifArrayEvent, NifSharedTypeDeepObservable, NifSharedTypeObservable},
     shared_type::{NifSharedType, SharedTypeId},
     transaction::TransactionResource,
@@ -18,12 +18,12 @@ pub type ArrayRefId = SharedTypeId<ArrayRef>;
 #[derive(NifStruct)]
 #[module = "Yex.Array"]
 pub struct NifArray {
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
     reference: ArrayRefId,
 }
 
 impl NifArray {
-    pub fn new(doc: ResourceArc<DocResource>, array: ArrayRef) -> Self {
+    pub fn new(doc: NifDoc, array: ArrayRef) -> Self {
         NifArray {
             doc,
             reference: ArrayRefId::new(array.hook()),
@@ -33,7 +33,7 @@ impl NifArray {
 impl NifSharedType for NifArray {
     type RefType = ArrayRef;
 
-    fn doc(&self) -> &ResourceArc<DocResource> {
+    fn doc(&self) -> &NifDoc {
         &self.doc
     }
     fn reference(&self) -> &SharedTypeId<Self::RefType> {

--- a/native/yex/src/awareness.rs
+++ b/native/yex/src/awareness.rs
@@ -40,7 +40,7 @@ pub struct NifAwarenessUpdateSummary {
 
 #[rustler::nif]
 fn awareness_new(doc: NifDoc) -> NifAwareness {
-    let awareness = Awareness::new(doc.clone());
+    let awareness = Awareness::new(doc.reference.0.clone());
     let resource = AwarenessResource::from(awareness);
     NifAwareness {
         reference: ResourceArc::new(resource),

--- a/native/yex/src/lib.rs
+++ b/native/yex/src/lib.rs
@@ -22,10 +22,10 @@ mod youtput;
 
 use any::NifAny;
 use array::NifArray;
-use doc::{DocResource, NifDoc};
+use doc::NifDoc;
 use error::Error;
 use map::NifMap;
-use rustler::{Env, NifStruct, ResourceArc};
+use rustler::{Env, NifStruct};
 use scoped_thread_local::scoped_thread_local;
 use text::NifText;
 
@@ -44,14 +44,14 @@ pub trait TryInto<T>: Sized {
 #[module = "Yex.WeakLink"]
 pub struct NifWeakLink {
     // not supported yet
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
 }
 
 #[derive(NifStruct)]
 #[module = "Yex.UndefinedRef"]
 pub struct NifUndefinedRef {
     // not supported yet or...?
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
 }
 
 rustler::init!("Elixir.Yex.Nif");

--- a/native/yex/src/map.rs
+++ b/native/yex/src/map.rs
@@ -1,9 +1,10 @@
 use crate::atoms;
+use crate::doc::NifDoc;
 use crate::event::{NifMapEvent, NifSharedTypeDeepObservable, NifSharedTypeObservable};
 use crate::shared_type::NifSharedType;
 use crate::shared_type::SharedTypeId;
 use crate::transaction::TransactionResource;
-use crate::{doc::DocResource, yinput::NifYInput, youtput::NifYOut, NifAny};
+use crate::{yinput::NifYInput, youtput::NifYOut, NifAny};
 use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
 use std::collections::HashMap;
 use yrs::types::ToJson;
@@ -13,11 +14,11 @@ pub type MapRefId = SharedTypeId<MapRef>;
 #[derive(NifStruct)]
 #[module = "Yex.Map"]
 pub struct NifMap {
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
     reference: MapRefId,
 }
 impl NifMap {
-    pub fn new(doc: ResourceArc<DocResource>, map: MapRef) -> Self {
+    pub fn new(doc: NifDoc, map: MapRef) -> Self {
         NifMap {
             doc,
             reference: MapRefId::new(map.hook()),
@@ -28,7 +29,7 @@ impl NifMap {
 impl NifSharedType for NifMap {
     type RefType = MapRef;
 
-    fn doc(&self) -> &ResourceArc<DocResource> {
+    fn doc(&self) -> &NifDoc {
         &self.doc
     }
     fn reference(&self) -> &SharedTypeId<Self::RefType> {

--- a/native/yex/src/shared_type.rs
+++ b/native/yex/src/shared_type.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use yrs::{Hook, ReadTxn, SharedRef, TransactionMut};
 
 use crate::{
-    doc::DocResource,
+    doc::NifDoc,
     transaction::{ReadTransaction, TransactionResource},
     wrap::SliceIntoBinary,
 };
@@ -50,7 +50,7 @@ where
     type RefType;
     const DELETED_ERROR: &'static str;
 
-    fn doc(&self) -> &ResourceArc<DocResource>;
+    fn doc(&self) -> &NifDoc;
     fn reference(&self) -> &SharedTypeId<Self::RefType>;
 
     fn get_ref<T: ReadTxn>(&self, txn: &T) -> NifResult<Self::RefType> {

--- a/native/yex/src/sticky_index.rs
+++ b/native/yex/src/sticky_index.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize as _, Serialize as _};
 use yrs::{Assoc, IndexedSequence, StickyIndex};
 
 use crate::{
-    atoms, doc::DocResource, shared_type::NifSharedType, transaction::TransactionResource,
+    atoms, doc::NifDoc, shared_type::NifSharedType, transaction::TransactionResource,
     wrap::SliceIntoBinary, yinput::NifSharedTypeInput,
 };
 
@@ -35,7 +35,7 @@ impl<'a> Decoder<'a> for StickyIndexRef {
 #[derive(NifStruct)]
 #[module = "Yex.StickyIndex"]
 pub struct NifStickyIndex {
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
     reference: StickyIndexRef,
     assoc: NifAssoc,
 }

--- a/native/yex/src/text.rs
+++ b/native/yex/src/text.rs
@@ -7,7 +7,7 @@ use yrs::*;
 use crate::{
     any::NifAttr,
     atoms,
-    doc::DocResource,
+    doc::NifDoc,
     event::{NifSharedTypeDeepObservable, NifSharedTypeObservable, NifTextEvent},
     shared_type::{NifSharedType, SharedTypeId},
     transaction::TransactionResource,
@@ -20,11 +20,11 @@ pub type TextRefId = SharedTypeId<TextRef>;
 #[derive(NifStruct)]
 #[module = "Yex.Text"]
 pub struct NifText {
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
     reference: TextRefId,
 }
 impl NifText {
-    pub fn new(doc: ResourceArc<DocResource>, text: TextRef) -> Self {
+    pub fn new(doc: NifDoc, text: TextRef) -> Self {
         NifText {
             doc,
             reference: TextRefId::new(text.hook()),
@@ -35,7 +35,7 @@ impl NifText {
 impl NifSharedType for NifText {
     type RefType = TextRef;
 
-    fn doc(&self) -> &ResourceArc<DocResource> {
+    fn doc(&self) -> &NifDoc {
         &self.doc
     }
     fn reference(&self) -> &SharedTypeId<Self::RefType> {
@@ -164,7 +164,7 @@ fn text_apply_delta(
 
 pub fn encode_diffs<'a>(
     diff: Vec<Diff<YChange>>,
-    doc: &ResourceArc<DocResource>,
+    doc: &NifDoc,
     env: Env<'a>,
 ) -> NifResult<Term<'a>> {
     let deltas: Vec<Term<'a>> = diff
@@ -173,11 +173,7 @@ pub fn encode_diffs<'a>(
         .collect::<Result<Vec<Term<'a>>, rustler::Error>>()?;
     Ok(deltas.encode(env))
 }
-pub fn encode_diff<'a>(
-    diff: &Diff<YChange>,
-    doc: &ResourceArc<DocResource>,
-    env: Env<'a>,
-) -> NifResult<Term<'a>> {
+pub fn encode_diff<'a>(diff: &Diff<YChange>, doc: &NifDoc, env: Env<'a>) -> NifResult<Term<'a>> {
     let insert = NifYOut::from_native(diff.insert.clone(), doc.clone());
 
     let mut attribute = diff.attributes.as_deref().map(|attr| {

--- a/native/yex/src/xml.rs
+++ b/native/yex/src/xml.rs
@@ -9,7 +9,7 @@ use yrs::{
 use crate::{
     any::NifAttr,
     atoms,
-    doc::DocResource,
+    doc::NifDoc,
     event::{NifSharedTypeDeepObservable, NifSharedTypeObservable, NifXmlEvent, NifXmlTextEvent},
     shared_type::{NifSharedType, SharedTypeId},
     text::encode_diffs,
@@ -26,12 +26,12 @@ pub type XmlTextId = SharedTypeId<XmlTextRef>;
 #[derive(NifStruct)]
 #[module = "Yex.XmlFragment"]
 pub struct NifXmlFragment {
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
     reference: XmlFragmentId,
 }
 
 impl NifXmlFragment {
-    pub fn new(doc: ResourceArc<DocResource>, xml: XmlFragmentRef) -> Self {
+    pub fn new(doc: NifDoc, xml: XmlFragmentRef) -> Self {
         Self {
             doc,
             reference: XmlFragmentId::new(xml.hook()),
@@ -42,7 +42,7 @@ impl NifXmlFragment {
 impl NifSharedType for NifXmlFragment {
     type RefType = XmlFragmentRef;
 
-    fn doc(&self) -> &ResourceArc<DocResource> {
+    fn doc(&self) -> &NifDoc {
         &self.doc
     }
     fn reference(&self) -> &SharedTypeId<Self::RefType> {
@@ -59,12 +59,12 @@ impl NifSharedTypeObservable for NifXmlFragment {
 #[derive(NifStruct)]
 #[module = "Yex.XmlElement"]
 pub struct NifXmlElement {
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
     reference: XmlElementId,
 }
 
 impl NifXmlElement {
-    pub fn new(doc: ResourceArc<DocResource>, xml: XmlElementRef) -> Self {
+    pub fn new(doc: NifDoc, xml: XmlElementRef) -> Self {
         Self {
             doc,
             reference: XmlElementId::new(xml.hook()),
@@ -79,7 +79,7 @@ impl NifSharedTypeObservable for NifXmlElement {
 impl NifSharedType for NifXmlElement {
     type RefType = XmlElementRef;
 
-    fn doc(&self) -> &ResourceArc<DocResource> {
+    fn doc(&self) -> &NifDoc {
         &self.doc
     }
     fn reference(&self) -> &SharedTypeId<Self::RefType> {
@@ -92,12 +92,12 @@ impl NifSharedType for NifXmlElement {
 #[derive(NifStruct)]
 #[module = "Yex.XmlText"]
 pub struct NifXmlText {
-    doc: ResourceArc<DocResource>,
+    doc: NifDoc,
     reference: XmlTextId,
 }
 
 impl NifXmlText {
-    pub fn new(doc: ResourceArc<DocResource>, xml: XmlTextRef) -> Self {
+    pub fn new(doc: NifDoc, xml: XmlTextRef) -> Self {
         Self {
             doc,
             reference: XmlTextId::new(xml.hook()),
@@ -108,7 +108,7 @@ impl NifXmlText {
 impl NifSharedType for NifXmlText {
     type RefType = XmlTextRef;
 
-    fn doc(&self) -> &ResourceArc<DocResource> {
+    fn doc(&self) -> &NifDoc {
         &self.doc
     }
     fn reference(&self) -> &SharedTypeId<Self::RefType> {

--- a/native/yex/src/youtput.rs
+++ b/native/yex/src/youtput.rs
@@ -2,9 +2,9 @@ use crate::{
     any::NifAny,
     doc::NifDoc,
     xml::{NifXmlElement, NifXmlFragment, NifXmlText},
-    DocResource, NifArray, NifMap, NifText, NifUndefinedRef, NifWeakLink,
+    NifArray, NifMap, NifText, NifUndefinedRef, NifWeakLink,
 };
-use rustler::{NifUntaggedEnum, ResourceArc};
+use rustler::NifUntaggedEnum;
 
 #[derive(NifUntaggedEnum)]
 pub enum NifYOut {
@@ -21,7 +21,7 @@ pub enum NifYOut {
 }
 
 impl NifYOut {
-    pub fn from_native(v: yrs::Out, doc: ResourceArc<DocResource>) -> Self {
+    pub fn from_native(v: yrs::Out, doc: NifDoc) -> Self {
         match v {
             yrs::Out::Any(any) => NifYOut::Any(any.into()),
             yrs::Out::YText(text) => NifYOut::YText(NifText::new(doc, text)),
@@ -34,7 +34,7 @@ impl NifYOut {
             yrs::Out::UndefinedRef(_) => NifYOut::UndefinedRef(NifUndefinedRef { doc }),
         }
     }
-    pub fn from_xml_out(v: yrs::XmlOut, doc: ResourceArc<DocResource>) -> Self {
+    pub fn from_xml_out(v: yrs::XmlOut, doc: NifDoc) -> Self {
         match v {
             yrs::XmlOut::Element(xml) => NifYOut::YXmlElement(NifXmlElement::new(doc, xml)),
             yrs::XmlOut::Fragment(xml) => NifYOut::YXmlFragment(NifXmlFragment::new(doc, xml)),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Type Changes**
  - Updated document reference types across multiple Elixir and Rust modules
  - Transitioned from generic references to more specific `Yex.Doc.t()` and `NifDoc` types

- **Shared Type Modifications**
  - Updated type definitions in `Yex.Array`, `Yex.Map`, `Yex.Text`, and other shared type modules
  - Modified private transaction handling methods to work with new document type structures

- **Rust Native Implementation**
  - Replaced `ResourceArc<DocResource>` with `NifDoc` in structs and method signatures
  - Updated document reference handling in array, map, text, and XML-related modules

- **Performance and Type Safety**
  - Improved type specificity for document references
  - Simplified resource management by removing intermediate type layers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->