### PR TITLE
Add `XmlElement.get_tag/1`

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -93,6 +93,7 @@ defmodule Yex.Nif do
   def xml_element_get_attribute(_xml_element, _cur_txn, _key),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def xml_element_get_tag(_xml_element, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def xml_element_get_attributes(_xml_element, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def xml_element_next_sibling(_xml_element, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def xml_element_prev_sibling(_xml_element, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/shared_type/xml_element.ex
+++ b/lib/shared_type/xml_element.ex
@@ -124,6 +124,16 @@ defmodule Yex.XmlElement do
     )
   end
 
+  @doc """
+  Get the tag of the xml element.
+  """
+  @spec get_tag(t) :: binary() | nil
+  def get_tag(%__MODULE__{doc: doc} = xml_element) do
+    Doc.run_in_worker_process(doc,
+      do: Yex.Nif.xml_element_get_tag(xml_element, cur_txn(xml_element))
+    )
+  end
+
   @spec get_attribute(t, binary()) :: binary() | nil
   def get_attribute(%__MODULE__{doc: doc} = xml_element, key) do
     Doc.run_in_worker_process(doc,

--- a/native/yex/src/xml.rs
+++ b/native/yex/src/xml.rs
@@ -297,6 +297,18 @@ fn xml_element_get_attribute(
 }
 
 #[rustler::nif]
+fn xml_element_get_tag(
+    xml: NifXmlElement,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+) -> NifResult<Option<String>> {
+    xml.readonly(current_transaction, |txn| {
+        let xml = xml.get_ref(txn)?;
+        let tag = xml.try_tag().map(|tag| tag.to_string());
+        Ok(tag)
+    })
+}
+
+#[rustler::nif]
 fn xml_element_remove_attribute(
     env: Env<'_>,
     xml: NifXmlElement,

--- a/test/shared_type/xml_element_test.exs
+++ b/test/shared_type/xml_element_test.exs
@@ -93,6 +93,11 @@ defmodule YexXmlElementTest do
       assert "<div></div>" == XmlElement.to_string(xml)
     end
 
+    test "get_tag", %{xml_element: xml1} do
+      tag = XmlElement.get_tag(xml1)
+      assert "div" == tag
+    end
+
     test "get_attributes", %{xml_element: xml1} do
       XmlElement.insert_attribute(xml1, "height", "10")
       XmlElement.insert_attribute(xml1, "width", "12")


### PR DESCRIPTION
`y_ex` provides an API for traversing XML elements and XML fragments. You can get children and element properties, but I couldn't find a way to get the tag name without using the `XmlElement.to_string()` method.

This PR exposes [`XmlElement.try_tag()` of `yrs`](https://github.com/y-crdt/y-crdt/blob/cfc383c9ddb1dc94f0494e4ca37175c1fd80438f/yrs/src/types/xml.rs#L258-L273) as the Elixir function `Yex.XmlElement.get_tag/1`.

I would like to avoid using `XmlElement.to_string()` if possible. The [implementation of `get_string()` in `yrs`](https://github.com/y-crdt/y-crdt/blob/main/yrs/src/types/xml.rs#L278-L297) seems to be intended primarily for debugging. It doesn't escape tags or quotes in the serialized stream, potentially producing broken XML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a capability to retrieve the tag from an XML element via a public interface, enhancing XML processing functionality.
- **Documentation**
  - Updated documentation to describe the new tag retrieval feature.
- **Tests**
  - Added tests to verify the correct extraction of tags from XML elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->