### PR TITLE
feat: add update_doc to shared_doc

### DIFF
--- a/lib/server/doc_server.ex
+++ b/lib/server/doc_server.ex
@@ -181,8 +181,6 @@ defmodule Yex.DocServer do
         Yex.DocServer.Worker.process_message_v1(server, message, origin)
       end
 
-      def get_doc(server), do: GenServer.call(server, {:get_doc})
-
       defoverridable child_spec: 1
     end
   end

--- a/lib/shared_type/shared_type.ex
+++ b/lib/shared_type/shared_type.ex
@@ -39,6 +39,7 @@ defmodule Yex.SharedType do
   @spec observe(t, keyword()) :: reference()
   def observe(%{doc: doc} = shared_type, opt \\ []) do
     ref = make_ref()
+    notify_pid = self()
 
     sub =
       Doc.run_in_worker_process(doc,
@@ -46,7 +47,7 @@ defmodule Yex.SharedType do
           Yex.Nif.shared_type_observe(
             shared_type,
             cur_txn(shared_type),
-            self(),
+            notify_pid,
             ref,
             Keyword.get(opt, :metadata)
           )
@@ -86,6 +87,7 @@ defmodule Yex.SharedType do
   @spec observe_deep(t, keyword()) :: reference()
   def observe_deep(%{doc: doc} = shared_type, opt \\ []) do
     ref = make_ref()
+    notify_pid = self()
 
     sub =
       Doc.run_in_worker_process(doc,
@@ -93,7 +95,7 @@ defmodule Yex.SharedType do
           Yex.Nif.shared_type_observe_deep(
             shared_type,
             cur_txn(shared_type),
-            self(),
+            notify_pid,
             ref,
             Keyword.get(opt, :metadata)
           )


### PR DESCRIPTION
Removed get_doc which did not work at all from DocServer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new functionalities to retrieve and update the shared document state through a consolidated API.
	- Deprecated a legacy document retrieval option to streamline document operations.
  
- **Tests**
	- Added tests verifying that document retrieval and update operations work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->