### PR TITLE
BREAKING CHANGE: convert safely representable f64 integers to floats for JS/Yjs compatibility

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -188,4 +188,7 @@ defmodule Yex.Nif do
   def undo_manager_exclude_origin(_undo_manager, _origin), do: :erlang.nif_error(:nif_not_loaded)
   def undo_manager_stop_capturing(_undo_manager), do: :erlang.nif_error(:nif_not_loaded)
   def undo_manager_clear(_undo_manager), do: :erlang.nif_error(:nif_not_loaded)
+
+  def normalize_number(_number),
+    do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/shared_type/array.ex
+++ b/lib/shared_type/array.ex
@@ -46,7 +46,7 @@ defmodule Yex.Array do
       iex> array = Yex.Doc.get_array(doc, "array")
       iex> Yex.Array.insert_list(array, 0, [1,2,3,4,5])
       iex> Yex.Array.to_json(array)
-      [1, 2, 3, 4, 5]
+      [1.0, 2.0, 3.0, 4.0, 5.0]
   """
   @spec insert_list(t, integer(), list()) :: :ok
   def insert_list(%__MODULE__{doc: doc} = array, index, contents) do
@@ -120,7 +120,7 @@ defmodule Yex.Array do
       iex> Yex.Array.push(array, Yex.ArrayPrelim.from([3, 4]))
       iex> :ok = Yex.Array.move_to(array, 0, 2)
       iex> Yex.Array.to_json(array)
-      [[3, 4], [1, 2]]
+      [[3.0, 4.0], [1.0, 2.0]]
   """
   @spec move_to(t, integer(), integer()) :: :ok
   def move_to(%__MODULE__{doc: doc} = array, from, to) do
@@ -214,6 +214,7 @@ defmodule Yex.Array do
   end
 
   def member?(array, val) do
+    val = Yex.normalize(val)
     Enum.member?(to_list(array), val)
   end
 

--- a/lib/shared_type/map.ex
+++ b/lib/shared_type/map.ex
@@ -233,6 +233,8 @@ defmodule Yex.Map do
     end
 
     def member?(map, {key, value}) do
+      value = Yex.normalize(value)
+
       case Yex.Map.fetch(map, key) do
         {:ok, ^value} -> {:ok, true}
         _ -> {:ok, false}

--- a/lib/y_ex.ex
+++ b/lib/y_ex.ex
@@ -109,6 +109,17 @@ defmodule Yex do
     Yex.Nif.apply_update_v2(doc, cur_txn(doc), update)
   end
 
+  @doc """
+  Normalize a number to a format that can be used in Yjs.
+  """
+  def normalize(number) when is_number(number) do
+    Yex.Nif.normalize_number(number)
+  end
+
+  def normalize(number) do
+    number
+  end
+
   defp cur_txn(%Yex.Doc{reference: doc_ref}) do
     Process.get(doc_ref, nil)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Yex.MixProject do
   use Mix.Project
 
-  @version "0.7.3"
+  @version "0.8.0"
   @repo "https://github.com/satoren/y_ex"
 
   @description """

--- a/native/yex/src/any.rs
+++ b/native/yex/src/any.rs
@@ -47,6 +47,8 @@ fn decode<'a>(term: Term<'a>) -> NifResult<Any> {
     } else if let Ok(v) = term.decode::<i32>() {
         return Ok(Any::Number(v.into()));
     } else if let Ok(v) = term.decode::<i64>() {
+        // Check if the number is within the safe integer range for f64
+        // If it is not, we return it as a BigInt
         if v > F64_MAX_SAFE_INTEGER as i64 || v < F64_MIN_SAFE_INTEGER as i64 {
             return Ok(Any::BigInt(v.into()));
         }

--- a/native/yex/src/any.rs
+++ b/native/yex/src/any.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::wrap::NifWrap;
 use rustler::types;
 use rustler::{Decoder, Encoder, Env, Error, ListIterator, MapIterator, NifResult, Term};
+use yrs::any::{F64_MAX_SAFE_INTEGER, F64_MIN_SAFE_INTEGER};
 use yrs::*;
 
 fn encode<'a>(env: Env<'a>, any: &Any) -> Term<'a> {
@@ -11,7 +12,7 @@ fn encode<'a>(env: Env<'a>, any: &Any) -> Term<'a> {
         Any::Null => types::atom::nil().to_term(env),
         Any::Undefined => types::atom::undefined().to_term(env),
         Any::Bool(b) => b.encode(env),
-        Any::Number(n) => n.encode(env),
+        Any::Number(num) => num.encode(env),
         Any::BigInt(n) => n.encode(env),
         Any::String(s) => s.encode(env),
         Any::Buffer(b) => b.encode(env),
@@ -43,8 +44,13 @@ fn decode<'a>(term: Term<'a>) -> NifResult<Any> {
             return Ok(Any::Undefined);
         }
         return Err(rustler::Error::BadArg);
+    } else if let Ok(v) = term.decode::<i32>() {
+        return Ok(Any::Number(v.into()));
     } else if let Ok(v) = term.decode::<i64>() {
-        return Ok(Any::BigInt(v));
+        if v > F64_MAX_SAFE_INTEGER as i64 || v < F64_MIN_SAFE_INTEGER as i64 {
+            return Ok(Any::BigInt(v.into()));
+        }
+        return Ok(Any::Number(v as f64));
     } else if let Ok(v) = term.decode::<f64>() {
         return Ok(Any::Number(v));
     } else if let Ok(v) = term.decode::<&str>() {
@@ -96,4 +102,9 @@ impl<'de, 'a: 'de> rustler::Encoder for NifAttr {
             .collect();
         map.encode(env)
     }
+}
+
+#[rustler::nif]
+fn normalize_number(any: NifAny) -> NifAny {
+    any
 }

--- a/native/yex/src/any.rs
+++ b/native/yex/src/any.rs
@@ -108,5 +108,7 @@ impl<'de, 'a: 'de> rustler::Encoder for NifAttr {
 
 #[rustler::nif]
 fn normalize_number(any: NifAny) -> NifAny {
+    // The data passes through Any, and gets converted.
+    // For example, even numbers within the SAFE_INTEGER range are converted to float type.
     any
 }

--- a/test/shared_type/map_test.exs
+++ b/test/shared_type/map_test.exs
@@ -14,6 +14,11 @@ defmodule Yex.MapTest do
       assert {:ok, "value"} = Map.fetch(map, "key")
     end
 
+    test "set/3 with big integer", %{map: map} do
+      assert :ok = Map.set(map, "key", 9_223_372_036_854_775_807)
+      assert {:ok, 9_223_372_036_854_775_807} = Map.fetch(map, "key")
+    end
+
     test "set/3 with complex values", %{map: map} do
       array_prelim = ArrayPrelim.from(["Hello", "World"])
       assert :ok = Map.set(map, "array", array_prelim)


### PR DESCRIPTION

integers that can be safely represented as f64 are now automatically converted to floats. This aligns with JavaScript behavior and reduces confusion when used with Yjs. However, this may cause issues in scenarios where values are added, retrieved, and compared as integers, since the original integer type information is not preserved.

fix https://github.com/satoren/y_ex/issues/156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a function to normalize numbers for consistent handling across the application.
  - Introduced a public normalization utility to ensure numeric values are converted to a standard format.

- **Bug Fixes**
  - Improved membership checks in arrays and maps by normalizing values before comparison, ensuring more reliable and consistent behavior.

- **Documentation**
  - Updated examples to reflect floating-point representations in array documentation.

- **Tests**
  - Expanded test coverage for arrays, maps, text, and XML elements, including edge cases, error handling, and support for large integers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->