### PR TITLE
feat: implement StickyIndex serialization APIs with encoding, decodin…

### DIFF
--- a/TODO_yffi_gap.md
+++ b/TODO_yffi_gap.md
@@ -12,7 +12,7 @@
 
 - [ ] Add JSONPath query APIs (ytransaction_json_path / yjson_path_iter_next / yjson_path_iter_destroy)
 - [ ] Add branch identification/re-resolution/liveness APIs (ybranch_id / ybranch_get / ybranch_alive / ybranch_json / ytype_get / ytype_kind)
-- [ ] Add StickyIndex serialization APIs (ysticky_index_encode / ysticky_index_decode / ysticky_index_to_json / ysticky_index_from_json / ysticky_index_assoc)
+- [x] Add StickyIndex serialization APIs (ysticky_index_encode / ysticky_index_decode / ysticky_index_to_json / ysticky_index_from_json / ysticky_index_assoc)
 - [ ] Add low-level XML traversal APIs (yxmlelem_tree_walker / yxmlelem_tree_walker_next / yxmlelem_tree_walker_destroy)
 - [ ] Add XML attribute-iterator APIs (yxmlelem_attr_iter / yxmltext_attr_iter / yxmlattr_iter_next / yxmlattr_destroy)
 - [ ] Add direct XmlText attribute APIs (yxmltext_insert_attr / yxmltext_remove_attr / yxmltext_get_attr)

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -187,6 +187,33 @@ defmodule Yex.Nif do
   def sticky_index_get_offset(_sticky_index, _cur_txn),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def sticky_index_encode(sticky_index),
+    do: sticky_index_encode_v1(sticky_index)
+
+  def sticky_index_decode(doc, binary),
+    do: sticky_index_decode_v1(doc, binary)
+
+  def sticky_index_to_json(_sticky_index),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def sticky_index_from_json(_json, _doc),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def sticky_index_assoc(_sticky_index),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def sticky_index_encode_v1(_sticky_index),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def sticky_index_decode_v1(_doc, _binary),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def sticky_index_encode_v2(_sticky_index),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def sticky_index_decode_v2(_doc, _binary),
+    do: :erlang.nif_error(:nif_not_loaded)
+
   def encode_state_vector_v1(_doc, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
   def encode_state_as_update_v1(_doc, _cur_txn, _diff), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/lib/sticky_index.ex
+++ b/lib/sticky_index.ex
@@ -71,6 +71,127 @@ defmodule Yex.StickyIndex do
     )
   end
 
+  @doc """
+  Encodes a StickyIndex to binary format using flexbuffer encoding (v1 - default).
+
+  This provides a compact binary representation suitable for storage or transmission.
+  The encoded binary can be decoded using `decode/2` or `decode_v1/2`.
+  """
+  @spec encode(t) :: {:ok, binary()} | {:error, term()}
+  def encode(%__MODULE__{doc: doc} = sticky_index) do
+    Doc.run_in_worker_process(doc, do: Yex.Nif.sticky_index_encode(sticky_index))
+  end
+
+  @doc """
+  Encodes a StickyIndex to binary flexbuffer format (v1).
+  """
+  @spec encode_v1(t) :: {:ok, binary()} | {:error, term()}
+  def encode_v1(%__MODULE__{doc: doc} = sticky_index) do
+    Doc.run_in_worker_process(doc, do: Yex.Nif.sticky_index_encode_v1(sticky_index))
+  end
+
+  @doc """
+  Encodes a StickyIndex to JSON string format (v2).
+
+  This provides a JSON string representation of the StickyIndex suitable for
+  interoperability with other systems.
+  """
+  @spec encode_v2(t) :: {:ok, binary()} | {:error, term()}
+  def encode_v2(%__MODULE__{doc: doc} = sticky_index) do
+    Doc.run_in_worker_process(doc, do: Yex.Nif.sticky_index_encode_v2(sticky_index))
+  end
+
+  @doc """
+  Decodes a StickyIndex from binary format with the given Doc context (v1 - default).
+
+  This reverses the encoding done by `encode/1` or `encode_v1/1`. The Doc is required
+  to associate the decoded StickyIndex with its document context.
+  """
+  @spec decode(Doc.t(), binary()) :: t
+  def decode(%Doc{} = doc, binary) when is_binary(binary) do
+    Doc.run_in_worker_process(doc, do: Yex.Nif.sticky_index_decode(doc, binary))
+  end
+
+  @doc """
+  Decodes a StickyIndex from binary flexbuffer format (v1).
+  """
+  @spec decode_v1(Doc.t(), binary()) :: t
+  def decode_v1(%Doc{} = doc, binary) when is_binary(binary) do
+    Doc.run_in_worker_process(doc, do: Yex.Nif.sticky_index_decode_v1(doc, binary))
+  end
+
+  @doc """
+  Decodes a StickyIndex from JSON string format (v2).
+
+  This reverses the encoding done by `encode_v2/1`. The Doc is required to associate
+  the decoded StickyIndex with its document context.
+  """
+  @spec decode_v2(Doc.t(), binary()) :: t
+  def decode_v2(%Doc{} = doc, binary) when is_binary(binary) do
+    Doc.run_in_worker_process(doc, do: Yex.Nif.sticky_index_decode_v2(doc, binary))
+  end
+
+  @doc """
+  Gets the association direction of a StickyIndex.
+
+  ## Returns
+
+  - `-1` for `:before` association
+  - `0` for `:after` association
+  """
+  @spec assoc(t) :: -1 | 0
+  def assoc(%__MODULE__{doc: doc} = sticky_index) do
+    Doc.run_in_worker_process(doc, do: Yex.Nif.sticky_index_assoc(sticky_index))
+  end
+
+  @doc """
+  Converts a StickyIndex to JSON representation.
+
+  Returns a serialized JSON string with StickyIndex position and association information in a format
+  compatible with Yjs RelativePosition and yffi's ysticky_index_to_json.
+
+  ## Returns
+
+  A JSON string containing an object with:
+  - Exactly one of `"item"`, `"type"`, or `"tname"`
+  - `"item"` - `{"client": u64, "clock": u32}` for relative positions in existing content
+  - `"type"` - `{"client": u64, "clock": u32}` for nested empty-type positions
+  - `"tname"` - Type name string for root-level empty-type positions
+  - `"assoc"` - Association value: `-1` for `:before`, `0` for `:after`
+  """
+  @spec to_json(t) :: String.t()
+  def to_json(%__MODULE__{doc: doc} = sticky_index) do
+    Doc.run_in_worker_process(doc, do: Yex.Nif.sticky_index_to_json(sticky_index))
+  end
+
+  @doc """
+  Reconstructs a StickyIndex from JSON representation.
+
+  This delegates to the reconstruction NIF (`Yex.Nif.sticky_index_from_json/2`).
+
+  ## Input constraints
+
+  - `json` must be a binary JSON payload in StickyIndex/RelativePosition format.
+  - `doc` must be a `%Yex.Doc{}` associated with the reconstructed StickyIndex.
+
+  ## Returns
+
+  - `{:ok, sticky_index}` when reconstruction succeeds
+  - `{:error, reason}` when reconstruction fails (for example `:invalid_json`)
+  """
+  @spec from_json(String.t(), Doc.t()) :: {:ok, t} | {:error, atom()}
+  def from_json(json, %Doc{} = doc) when is_binary(json) do
+    Doc.run_in_worker_process(doc,
+      do:
+        case Yex.Nif.sticky_index_from_json(json, doc) do
+          {:ok, result} -> {:ok, result}
+          {:error, reason} -> {:error, reason}
+        end
+    )
+  end
+
+  @doc false
+  # Gets the current transaction reference from the process dictionary for the given document
   defp cur_txn(%{doc: %Yex.Doc{reference: doc_ref}}) do
     Process.get(doc_ref, nil)
   end

--- a/native/yex/src/array.rs
+++ b/native/yex/src/array.rs
@@ -75,7 +75,7 @@ fn array_insert_list(
     array.mutably(env, current_transaction, |txn| {
         let array = array.get_ref(txn)?;
         let index = normalize_index_for_insert(array.len(txn), index);
-        array.insert_range(txn, index, values.into_iter().map(|a| a.0.clone()));
+        array.insert_range(txn, index, values.into_iter().map(|a| a.0));
         Ok(atoms::ok())
     })
 }

--- a/native/yex/src/atoms.rs
+++ b/native/yex/src/atoms.rs
@@ -1,6 +1,7 @@
 rustler::atoms! {
     ok,
     error,
+  invalid_json,
     terminated,
     poison_error,
     transaction_acq_error,

--- a/native/yex/src/event.rs
+++ b/native/yex/src/event.rs
@@ -80,12 +80,12 @@ impl rustler::Encoder for NifYArrayChange {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         let v: Vec<Term<'_>> = self
             .change
-            .clone()
-            .into_iter()
+            .iter()
             .map(|change| match change {
                 Change::Added(content) => {
                     let content: Vec<Term<'_>> = content
-                        .into_iter()
+                        .iter()
+                        .cloned()
                         .map(|item| NifYOut::from_native(item, self.doc.clone()).encode(env))
                         .collect();
 
@@ -95,12 +95,12 @@ impl rustler::Encoder for NifYArrayChange {
                 }
                 Change::Removed(index) => {
                     let mut map = Term::map_new(env);
-                    map = map.map_put(atoms::delete(), index).unwrap();
+                    map = map.map_put(atoms::delete(), *index).unwrap();
                     map
                 }
                 Change::Retain(index) => {
                     let mut map = Term::map_new(env);
-                    map = map.map_put(atoms::retain(), index).unwrap();
+                    map = map.map_put(atoms::retain(), *index).unwrap();
                     map
                 }
             })
@@ -152,11 +152,10 @@ impl rustler::Encoder for NifYTextDelta {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         let v: Vec<Term<'_>> = self
             .delta
-            .clone()
-            .into_iter()
+            .iter()
             .map(|change| match change {
                 Delta::Inserted(content, attr) => {
-                    let insert = NifYOut::from_native(content, self.doc.clone());
+                    let insert = NifYOut::from_native(content.clone(), self.doc.clone());
 
                     let mut map = Term::map_new(env).map_put(atoms::insert(), insert).unwrap();
                     if let Some(attr) = attr {
@@ -170,12 +169,12 @@ impl rustler::Encoder for NifYTextDelta {
                 }
                 Delta::Deleted(index) => {
                     let mut map = Term::map_new(env);
-                    map = map.map_put(atoms::delete(), index).unwrap();
+                    map = map.map_put(atoms::delete(), *index).unwrap();
                     map
                 }
                 Delta::Retain(index, attr) => {
                     let mut map = Term::map_new(env);
-                    map = map.map_put(atoms::retain(), index).unwrap();
+                    map = map.map_put(atoms::retain(), *index).unwrap();
                     if let Some(attr) = attr {
                         let attribute = attr
                             .iter()
@@ -227,11 +226,10 @@ impl rustler::Encoder for NifYMapChange {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         let v: HashMap<String, Term> = self
             .change
-            .clone()
-            .into_iter()
+            .iter()
             .map(|(key, change)| match change {
                 EntryChange::Inserted(content) => {
-                    let content = NifYOut::from_native(content, self.doc.clone());
+                    let content = NifYOut::from_native(content.clone(), self.doc.clone());
                     let map = Term::map_new(env)
                         .map_put(atoms::action(), atoms::add())
                         .unwrap()
@@ -240,7 +238,7 @@ impl rustler::Encoder for NifYMapChange {
                     (key.to_string(), map)
                 }
                 EntryChange::Removed(old_value) => {
-                    let old_value = NifYOut::from_native(old_value, self.doc.clone());
+                    let old_value = NifYOut::from_native(old_value.clone(), self.doc.clone());
                     let map = Term::map_new(env)
                         .map_put(atoms::action(), atoms::delete())
                         .unwrap()
@@ -249,8 +247,8 @@ impl rustler::Encoder for NifYMapChange {
                     (key.to_string(), map)
                 }
                 EntryChange::Updated(old_value, new_value) => {
-                    let old_value = NifYOut::from_native(old_value, self.doc.clone());
-                    let new_value = NifYOut::from_native(new_value, self.doc.clone());
+                    let old_value = NifYOut::from_native(old_value.clone(), self.doc.clone());
+                    let new_value = NifYOut::from_native(new_value.clone(), self.doc.clone());
                     let map = Term::map_new(env)
                         .map_put(atoms::action(), atoms::update())
                         .unwrap()
@@ -369,21 +367,19 @@ pub enum NifEvent {
 }
 
 impl NifEvent {
-    pub fn new(doc: NifDoc, event: &yrs::types::Event, txn: &TransactionMut<'_>) -> Self {
+    pub fn new(doc: &NifDoc, event: &yrs::types::Event, txn: &TransactionMut<'_>) -> Self {
         match event {
-            yrs::types::Event::Text(event) => NifEvent::Text(NifTextEvent::new(&doc, event, txn)),
-            yrs::types::Event::Array(event) => {
-                NifEvent::Array(NifArrayEvent::new(&doc, event, txn))
-            }
-            yrs::types::Event::Map(event) => NifEvent::Map(NifMapEvent::new(&doc, event, txn)),
+            yrs::types::Event::Text(event) => NifEvent::Text(NifTextEvent::new(doc, event, txn)),
+            yrs::types::Event::Array(event) => NifEvent::Array(NifArrayEvent::new(doc, event, txn)),
+            yrs::types::Event::Map(event) => NifEvent::Map(NifMapEvent::new(doc, event, txn)),
             yrs::types::Event::XmlFragment(event) => {
-                NifEvent::XmlFragment(NifXmlEvent::new(&doc, event, txn))
+                NifEvent::XmlFragment(NifXmlEvent::new(doc, event, txn))
             }
             yrs::types::Event::XmlText(event) => {
-                NifEvent::XmlText(NifXmlTextEvent::new(&doc, event, txn))
+                NifEvent::XmlText(NifXmlTextEvent::new(doc, event, txn))
             }
             yrs::types::Event::Weak(event) => {
-                NifEvent::Weak(NifWeakLinkEvent::new(&doc, event, txn))
+                NifEvent::Weak(NifWeakLinkEvent::new(doc, event, txn))
             }
         }
     }
@@ -411,11 +407,10 @@ where
 
             let doc_ref = doc.clone();
             let sub = ref_value.observe_deep(move |txn, events| {
-                let doc_ref = doc_ref.clone();
                 ENV.with(|env| {
                     let events: Vec<NifEvent> = events
                         .iter()
-                        .map(|event| NifEvent::new(doc_ref.clone(), event, txn))
+                        .map(|event| NifEvent::new(&doc_ref, event, txn))
                         .collect();
                     let _ = env.send(
                         &pid,
@@ -463,7 +458,6 @@ where
 
             let doc_ref = doc.clone();
             let sub = ref_value.observe(move |txn, event| {
-                let doc_ref = doc_ref.clone();
                 ENV.with(|env| {
                     let _ = env.send(
                         &pid,

--- a/native/yex/src/sticky_index.rs
+++ b/native/yex/src/sticky_index.rs
@@ -1,12 +1,14 @@
 use rustler::{Atom, Decoder, Encoder, Env, NifResult, NifStruct, NifUnitEnum, ResourceArc, Term};
 use serde::{Deserialize as _, Serialize as _};
+use yrs::updates::decoder::Decode;
+use yrs::updates::encoder::Encode;
 use yrs::{Assoc, IndexedSequence, StickyIndex};
 
+use crate::error::Error;
 use crate::{
     atoms, doc::NifDoc, shared_type::NifSharedType, transaction::TransactionResource,
     utils::normalize_index, wrap::SliceIntoBinary, yinput::NifSharedTypeInput,
 };
-
 pub struct StickyIndexRef(pub StickyIndex);
 impl StickyIndexRef {
     pub fn new(v: StickyIndex) -> Self {
@@ -60,11 +62,6 @@ impl From<&NifAssoc> for Assoc {
             NifAssoc::After => Assoc::After,
             NifAssoc::Before => Assoc::Before,
         }
-    }
-}
-impl From<&NifStickyIndex> for StickyIndex {
-    fn from(val: &NifStickyIndex) -> Self {
-        val.reference.0.clone()
     }
 }
 
@@ -134,10 +131,14 @@ fn sticky_index_get_offset(
     sticky_index: NifStickyIndex,
     current_transaction: Option<ResourceArc<TransactionResource>>,
 ) -> NifResult<(Atom, NifOffset)> {
-    let doc = sticky_index.doc.clone();
+    let NifStickyIndex {
+        doc,
+        reference,
+        assoc: _,
+    } = sticky_index;
 
     doc.readonly(current_transaction, |txn| {
-        let sticky_index = sticky_index.reference.0;
+        let sticky_index = reference.0;
         match sticky_index.get_offset(txn) {
             Some(offset) => Ok((
                 atoms::ok(),
@@ -148,5 +149,88 @@ fn sticky_index_get_offset(
             )),
             None => Err(rustler::Error::Atom("error")),
         }
+    })
+}
+
+#[rustler::nif]
+fn sticky_index_to_json(sticky_index: NifStickyIndex) -> NifResult<String> {
+    serde_json::to_string(&sticky_index.reference.0).map_err(|_| rustler::Error::BadArg)
+}
+
+#[rustler::nif]
+fn sticky_index_from_json<'a>(
+    env: Env<'a>,
+    json: rustler::Binary,
+    doc: NifDoc,
+) -> NifResult<Term<'a>> {
+    match serde_json::from_slice::<StickyIndex>(json.as_slice()) {
+        Ok(pos) => {
+            let assoc = pos.assoc.into();
+            Ok((
+                atoms::ok(),
+                NifStickyIndex {
+                    doc,
+                    reference: StickyIndexRef::new(pos),
+                    assoc,
+                },
+            )
+                .encode(env))
+        }
+        Err(_) => Ok((atoms::error(), atoms::invalid_json()).encode(env)),
+    }
+}
+
+#[rustler::nif]
+fn sticky_index_assoc(sticky_index: NifStickyIndex) -> NifResult<i32> {
+    let assoc_value = match sticky_index.assoc {
+        NifAssoc::Before => -1,
+        NifAssoc::After => 0,
+    };
+    Ok(assoc_value)
+}
+
+// Version 1: Flexbuffer format (default)
+#[rustler::nif]
+fn sticky_index_encode_v1(env: Env<'_>, sticky_index: NifStickyIndex) -> NifResult<Term<'_>> {
+    let binary = sticky_index.reference.0.encode_v1();
+    Ok((atoms::ok(), SliceIntoBinary::new(binary.as_slice())).encode(env))
+}
+
+#[rustler::nif]
+fn sticky_index_decode_v1(
+    env: Env<'_>,
+    doc: NifDoc,
+    binary: rustler::types::Binary<'_>,
+) -> NifResult<NifStickyIndex> {
+    let _ = env;
+    let sticky_index_ref = StickyIndex::decode_v1(binary.as_slice()).map_err(Error::from)?;
+
+    Ok(NifStickyIndex {
+        doc,
+        reference: StickyIndexRef::new(sticky_index_ref),
+        assoc: NifAssoc::After,
+    })
+}
+
+// Version 2: JSON format
+#[rustler::nif]
+fn sticky_index_encode_v2(env: Env<'_>, sticky_index: NifStickyIndex) -> NifResult<Term<'_>> {
+    let binary = sticky_index.reference.0.encode_v2();
+    Ok((atoms::ok(), SliceIntoBinary::new(binary.as_slice())).encode(env))
+}
+
+#[rustler::nif]
+fn sticky_index_decode_v2(
+    env: Env<'_>,
+    doc: NifDoc,
+    binary: rustler::types::Binary<'_>,
+) -> NifResult<NifStickyIndex> {
+    let _ = env;
+    let sticky_index_ref = StickyIndex::decode_v2(binary.as_slice()).map_err(Error::from)?;
+
+    Ok(NifStickyIndex {
+        doc,
+        reference: StickyIndexRef::new(sticky_index_ref),
+        assoc: NifAssoc::After,
     })
 }

--- a/test/sticky_index_test.exs
+++ b/test/sticky_index_test.exs
@@ -15,6 +15,17 @@ defmodule Yex.StickyIndexTest do
 
   doctest StickyIndex
 
+  defp decode_json!(json) when is_binary(json) do
+    if Code.ensure_loaded?(Jason) and function_exported?(Jason, :decode!, 1) do
+      Jason.decode!(json)
+    else
+      case :json.decode(json) do
+        {:ok, decoded} -> decoded
+        decoded -> decoded
+      end
+    end
+  end
+
   test "new" do
     doc = Doc.new()
     txt = Doc.get_text(doc, "text")
@@ -132,7 +143,7 @@ defmodule Yex.StickyIndexTest do
       # since the content it was pointing to was deleted
       {:ok, result} = StickyIndex.get_offset(pos)
 
-      # The actual index will depend on the Yjs implementation 
+      # The actual index will depend on the Yjs implementation
       # We'll just verify it returns a result without asserting the exact position
       assert is_map(result)
       assert Map.has_key?(result, :index)
@@ -185,5 +196,312 @@ defmodule Yex.StickyIndexTest do
     assert_raise ErlangError, fn ->
       StickyIndex.get_offset(invalid_index)
     end
+  end
+
+  test "encode and decode sticky index" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    # Create and encode a sticky index
+    pos =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "hello")
+        StickyIndex.new(txt, 2, :after)
+      end)
+
+    # Encode the position
+    {:ok, binary} = StickyIndex.encode(pos)
+    assert is_binary(binary)
+    assert byte_size(binary) > 0
+
+    # Decode the binary back
+    decoded_pos = StickyIndex.decode(doc, binary)
+    assert decoded_pos.doc == pos.doc
+    assert decoded_pos.assoc == pos.assoc
+
+    # Verify the decoded position works
+    Doc.transaction(doc, fn ->
+      {:ok, offset} = StickyIndex.get_offset(decoded_pos)
+      assert offset.index == 2
+      assert offset.assoc == :after
+    end)
+  end
+
+  test "encode and decode with modifications" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    # Create, modify, encode, then decode
+    {:ok, binary} =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "abc")
+        pos = StickyIndex.new(txt, 1, :before)
+
+        # Modify text
+        Text.insert(txt, 0, "xyz")
+
+        # Encode after modifications
+        StickyIndex.encode(pos)
+      end)
+
+    # Decode after transaction completes
+    decoded_pos = StickyIndex.decode(doc, binary)
+
+    # Verify the decoded position works
+    Doc.transaction(doc, fn ->
+      {:ok, offset} = StickyIndex.get_offset(decoded_pos)
+      assert offset.index == 4
+      assert offset.assoc == :before
+    end)
+  end
+
+  test "sticky_index_to_json returns JSON string with assoc (ysticky_index_to_json compatible)" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    # Test :after association (assoc = 0)
+    pos_after =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "hello")
+        StickyIndex.new(txt, 2, :after)
+      end)
+
+    json_after = StickyIndex.to_json(pos_after)
+    assert is_binary(json_after)
+    assert decode_json!(json_after)["assoc"] == 0
+
+    # Test :before association (assoc = -1)
+    pos_before =
+      Doc.transaction(doc, fn ->
+        StickyIndex.new(txt, 3, :before)
+      end)
+
+    json_before = StickyIndex.to_json(pos_before)
+    assert is_binary(json_before)
+    assert decode_json!(json_before)["assoc"] == -1
+  end
+
+  test "sticky_index_assoc returns correct values" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    # Test :after association (assoc = 0)
+    pos_after =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "hello")
+        StickyIndex.new(txt, 1, :after)
+      end)
+
+    assert StickyIndex.assoc(pos_after) == 0
+
+    # Test :before association (assoc = -1)
+    pos_before =
+      Doc.transaction(doc, fn ->
+        StickyIndex.new(txt, 2, :before)
+      end)
+
+    assert StickyIndex.assoc(pos_before) == -1
+  end
+
+  test "encode produces different binaries for different positions" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    pos1 =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "hello world")
+        StickyIndex.new(txt, 1, :after)
+      end)
+
+    pos2 =
+      Doc.transaction(doc, fn ->
+        StickyIndex.new(txt, 5, :after)
+      end)
+
+    binary1 = StickyIndex.encode(pos1)
+    binary2 = StickyIndex.encode(pos2)
+
+    # Different positions should produce different encodings
+    assert binary1 != binary2
+  end
+
+  test "encode produces same binary for same position" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    pos =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "test")
+        StickyIndex.new(txt, 2, :before)
+      end)
+
+    binary1 = StickyIndex.encode(pos)
+    binary2 = StickyIndex.encode(pos)
+
+    # Same position encoded twice should produce same binary
+    assert binary1 == binary2
+  end
+
+  test "to_json emits item-variant JSON structure" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    pos =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "hello world")
+        StickyIndex.new(txt, 5, :after)
+      end)
+
+    json = StickyIndex.to_json(pos)
+
+    assert is_binary(json)
+    decoded = decode_json!(json)
+    assert is_map(decoded)
+
+    assert Map.has_key?(decoded, "item")
+    refute Map.has_key?(decoded, "type")
+    refute Map.has_key?(decoded, "tname")
+
+    assert is_map(decoded["item"])
+    assert is_integer(decoded["item"]["client"])
+    assert is_integer(decoded["item"]["clock"])
+    assert decoded["assoc"] == 0
+  end
+
+  test "from_json can reconstruct sticky index from JSON" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    # Create initial position
+    original_pos =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "test content")
+        StickyIndex.new(txt, 4, :before)
+      end)
+
+    # Export to JSON
+    json = StickyIndex.to_json(original_pos)
+
+    # Reconstruct from JSON
+    {:ok, restored_pos} = StickyIndex.from_json(json, doc)
+
+    # Verify restored position has correct assoc
+    assert StickyIndex.assoc(restored_pos) == -1
+
+    # Verify restored position points to the same offset as the original
+    Doc.transaction(doc, fn ->
+      {:ok, original_offset} = StickyIndex.get_offset(original_pos)
+      {:ok, restored_offset} = StickyIndex.get_offset(restored_pos)
+
+      assert restored_offset.index == original_offset.index
+      assert restored_offset.assoc == original_offset.assoc
+    end)
+
+    # Verify JSON roundtrip
+    restored_json = StickyIndex.to_json(restored_pos)
+    assert decode_json!(restored_json)["assoc"] == decode_json!(json)["assoc"]
+  end
+
+  test "to_json can emit type-variant JSON structure" do
+    doc = Doc.new()
+    json = ~s({"type":{"client":1,"clock":0},"assoc":0})
+
+    {:ok, pos} = StickyIndex.from_json(json, doc)
+    encoded = StickyIndex.to_json(pos) |> decode_json!()
+
+    assert Map.has_key?(encoded, "type")
+    refute Map.has_key?(encoded, "item")
+    refute Map.has_key?(encoded, "tname")
+
+    assert is_map(encoded["type"])
+    assert is_integer(encoded["type"]["client"])
+    assert is_integer(encoded["type"]["clock"])
+    assert encoded["assoc"] == 0
+  end
+
+  test "to_json can emit tname-variant JSON structure" do
+    doc = Doc.new()
+
+    {:ok, tname_pos} = StickyIndex.from_json(~s({"tname":"text","assoc":0}), doc)
+    encoded = StickyIndex.to_json(tname_pos) |> decode_json!()
+
+    assert Map.has_key?(encoded, "tname")
+    refute Map.has_key?(encoded, "item")
+    refute Map.has_key?(encoded, "type")
+
+    assert is_binary(encoded["tname"])
+    assert encoded["assoc"] == 0
+  end
+
+  test "from_json with :after association" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    original_pos =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "content")
+        StickyIndex.new(txt, 3, :after)
+      end)
+
+    json = StickyIndex.to_json(original_pos)
+    {:ok, restored_pos} = StickyIndex.from_json(json, doc)
+
+    assert StickyIndex.assoc(restored_pos) == 0
+    assert decode_json!(StickyIndex.to_json(restored_pos))["assoc"] == 0
+  end
+
+  test "from_json returns error for invalid JSON" do
+    doc = Doc.new()
+
+    assert {:error, reason} = StickyIndex.from_json("not valid json", doc)
+    assert reason == :invalid_json
+  end
+
+  test "encode_v1 and decode_v1 roundtrip" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    pos =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "hello")
+        StickyIndex.new(txt, 2, :after)
+      end)
+
+    {:ok, binary} = StickyIndex.encode_v1(pos)
+    assert is_binary(binary)
+    assert byte_size(binary) > 0
+
+    decoded_pos = StickyIndex.decode_v1(doc, binary)
+    assert decoded_pos.doc == pos.doc
+
+    Doc.transaction(doc, fn ->
+      {:ok, offset} = StickyIndex.get_offset(decoded_pos)
+      assert offset.index == 2
+      assert offset.assoc == :after
+    end)
+  end
+
+  test "encode_v2 and decode_v2 roundtrip" do
+    doc = Doc.new()
+    txt = Doc.get_text(doc, "text")
+
+    pos =
+      Doc.transaction(doc, fn ->
+        Text.insert(txt, 0, "hello")
+        StickyIndex.new(txt, 3, :before)
+      end)
+
+    {:ok, binary} = StickyIndex.encode_v2(pos)
+    assert is_binary(binary)
+    assert byte_size(binary) > 0
+
+    decoded_pos = StickyIndex.decode_v2(doc, binary)
+    assert decoded_pos.doc == pos.doc
+
+    Doc.transaction(doc, fn ->
+      {:ok, offset} = StickyIndex.get_offset(decoded_pos)
+      assert offset.index == 3
+      assert offset.assoc == :before
+    end)
   end
 end


### PR DESCRIPTION
…g, and JSON conversion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sticky index serialization/deserialization with versioned helpers (including flexbuffer v1/v2 flows).
  * Added JSON conversion for sticky indexes via `to_json/1` and `from_json/2`.
  * Added sticky index association metadata access via `assoc/1`, ensuring it’s preserved across document updates.
* **Tests**
  * Expanded ExUnit coverage for encode/decode behavior, JSON round-trips (including invalid JSON), deterministic encoding, and correct offset/association handling after in-document modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->