### PR TITLE
feat: add get_pending_update and get_pending_ds functions with tests

### DIFF
--- a/benchmark/apply_update.exs
+++ b/benchmark/apply_update.exs
@@ -1,0 +1,63 @@
+# Benchmark for `apply_update_v1/2` and `apply_update_v2/2` NIFs.
+# Measures only decode + apply cost; doc creation is in before_each (not measured).
+# Run with: MIX_ENV=prod mix run benchmark/apply_update.exs
+
+alias Yex.{Doc, Array, Text}
+
+build_update_v1 = fn insert_fn ->
+  src = Doc.new()
+  insert_fn.(src)
+  {:ok, update} = Yex.encode_state_as_update_v1(src)
+  update
+end
+
+build_update_v2 = fn insert_fn ->
+  src = Doc.new()
+  insert_fn.(src)
+  {:ok, update} = Yex.encode_state_as_update_v2(src)
+  update
+end
+
+IO.puts("\n=== apply_update_v1 vs apply_update_v2 (NIF direct) ===\n")
+
+Benchee.run(
+  %{
+    # Call NIF directly: no worker_pid routing, so before_each doc survives into memory measurement
+    "apply_update_v1" => fn %{doc: doc, update_v1: update} ->
+      Yex.Nif.apply_update_v1(doc, nil, update)
+    end,
+    "apply_update_v2" => fn %{doc: doc, update_v2: update} ->
+      Yex.Nif.apply_update_v2(doc, nil, update)
+    end
+  },
+  inputs: %{
+    "text 100 chars" => fn doc ->
+      text = Doc.get_text(doc, "text")
+      Text.insert(text, 0, String.duplicate("x", 100))
+    end,
+    "text 10_000 chars" => fn doc ->
+      text = Doc.get_text(doc, "text")
+      Text.insert(text, 0, String.duplicate("x", 10_000))
+    end,
+    "array 100 items" => fn doc ->
+      arr = Doc.get_array(doc, "array")
+      Array.insert_list(arr, 0, List.duplicate("x", 100))
+    end,
+    "array 10_000 items" => fn doc ->
+      arr = Doc.get_array(doc, "array")
+      Array.insert_list(arr, 0, List.duplicate("x", 10_000))
+    end
+  },
+  before_scenario: fn insert_fn ->
+    %{
+      update_v1: build_update_v1.(insert_fn),
+      update_v2: build_update_v2.(insert_fn)
+    }
+  end,
+  before_each: fn %{update_v1: u1, update_v2: u2} ->
+    # fresh doc per iteration so accumulated state does not affect timing
+    %{doc: Yex.Nif.doc_new(), update_v1: u1, update_v2: u2}
+  end,
+  memory_time: 2,
+  time: 5
+)

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -230,6 +230,9 @@ defmodule Yex.Nif do
   def merge_updates_v2(_updates), do: :erlang.nif_error(:nif_not_loaded)
   def update_debug_v2(_update), do: :erlang.nif_error(:nif_not_loaded)
 
+  def get_pending_update_v1(_doc, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
+  def get_pending_ds_v1(_doc, _cur_txn), do: :erlang.nif_error(:nif_not_loaded)
+
   def sync_message_decode_v1(_message), do: :erlang.nif_error(:nif_not_loaded)
   def sync_message_encode_v1(_message), do: :erlang.nif_error(:nif_not_loaded)
   def sync_messages_encode_v1(_messages), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/y_ex.ex
+++ b/lib/y_ex.ex
@@ -164,6 +164,34 @@ defmodule Yex do
   end
 
   @doc """
+  Returns the pending update (v1 encoded) for the document, if any.
+
+  A pending update accumulates operations that arrived out of order and
+  could not yet be applied because their causal predecessors are missing.
+  Returns `{:ok, binary()}` when a pending update exists, `{:ok, nil}` otherwise.
+  """
+  @spec get_pending_update(Yex.Doc.t()) :: {:ok, binary() | nil} | {:error, term()}
+  def get_pending_update(%Yex.Doc{} = doc) do
+    Yex.Doc.run_in_worker_process doc do
+      Yex.Nif.get_pending_update_v1(doc, cur_txn(doc))
+    end
+  end
+
+  @doc """
+  Returns the pending delete set (v1 encoded) for the document, if any.
+
+  A pending delete set holds deletions that arrived out of order and could
+  not yet be applied. Returns `{:ok, binary()}` when a pending delete set
+  exists, `{:ok, nil}` otherwise.
+  """
+  @spec get_pending_ds(Yex.Doc.t()) :: {:ok, binary() | nil} | {:error, term()}
+  def get_pending_ds(%Yex.Doc{} = doc) do
+    Yex.Doc.run_in_worker_process doc do
+      Yex.Nif.get_pending_ds_v1(doc, cur_txn(doc))
+    end
+  end
+
+  @doc """
   Normalize a number to a format that can be used in Yjs.
   """
   def normalize(number) when is_number(number) do

--- a/native/yex/src/doc.rs
+++ b/native/yex/src/doc.rs
@@ -500,6 +500,36 @@ fn encode_state_as_update_v2<'a>(
 }
 
 #[rustler::nif]
+fn get_pending_update_v1<'a>(
+    env: Env<'a>,
+    doc: NifDoc,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+) -> NifResult<Term<'a>> {
+    doc.readonly(current_transaction, |txn| {
+        let result = txn.store().pending_update().map(|p| {
+            let bytes = p.update.encode_v1();
+            SliceIntoBinary::new(bytes.as_slice()).encode(env)
+        });
+        Ok((atoms::ok(), result).encode(env))
+    })
+}
+
+#[rustler::nif]
+fn get_pending_ds_v1<'a>(
+    env: Env<'a>,
+    doc: NifDoc,
+    current_transaction: Option<ResourceArc<TransactionResource>>,
+) -> NifResult<Term<'a>> {
+    doc.readonly(current_transaction, |txn| {
+        let result = txn.store().pending_ds().map(|ds| {
+            let bytes = ds.encode_v1();
+            SliceIntoBinary::new(bytes.as_slice()).encode(env)
+        });
+        Ok((atoms::ok(), result).encode(env))
+    })
+}
+
+#[rustler::nif]
 fn doc_monitor_subdocs(
     doc: NifDoc,
     pid: LocalPid,

--- a/test/y_ex_test.exs
+++ b/test/y_ex_test.exs
@@ -151,4 +151,112 @@ defmodule YexTest do
       {:ok, _binary} = Yex.encode_state_vector_v2(doc)
     end
   end
+
+  describe "get_pending_update / get_pending_ds" do
+    test "returns nil when no pending update exists" do
+      doc = Yex.Doc.new()
+      assert {:ok, nil} = Yex.get_pending_update(doc)
+      assert {:ok, nil} = Yex.get_pending_ds(doc)
+    end
+
+    test "returns nil for a doc that has content but no missing dependencies" do
+      doc = Yex.Doc.new()
+      text = Yex.Doc.get_text(doc, "text")
+      Yex.Text.insert(text, 0, "Hello")
+      assert {:ok, nil} = Yex.get_pending_update(doc)
+      assert {:ok, nil} = Yex.get_pending_ds(doc)
+    end
+
+    test "returns binary pending update when update arrives out of order" do
+      # Apply the second chunk of an update before the first to create a pending update.
+      doc1 = Yex.Doc.new()
+      text = Yex.Doc.get_text(doc1, "text")
+      {:ok, sv_empty} = Yex.encode_state_vector(doc1)
+      Yex.Text.insert(text, 0, "Hello")
+      {:ok, update_a} = Yex.encode_state_as_update(doc1, sv_empty)
+      {:ok, sv_a} = Yex.encode_state_vector(doc1)
+      Yex.Text.insert(text, 5, " World")
+      {:ok, update_b} = Yex.encode_state_as_update(doc1, sv_a)
+
+      # doc2 receives update_b (depends on update_a) before update_a → pending
+      doc2 = Yex.Doc.new()
+      :ok = Yex.apply_update(doc2, update_b)
+
+      assert {:ok, pending} = Yex.get_pending_update(doc2)
+      assert is_binary(pending)
+      assert byte_size(pending) > 0
+
+      # After applying the missing update, pending clears
+      :ok = Yex.apply_update(doc2, update_a)
+      assert {:ok, nil} = Yex.get_pending_update(doc2)
+    end
+
+    test "pending update is re-encodable as a valid v1 update" do
+      doc1 = Yex.Doc.new()
+      text = Yex.Doc.get_text(doc1, "text")
+      {:ok, sv_empty} = Yex.encode_state_vector(doc1)
+      Yex.Text.insert(text, 0, "Hello")
+      {:ok, _update_a} = Yex.encode_state_as_update(doc1, sv_empty)
+      {:ok, sv_a} = Yex.encode_state_vector(doc1)
+      Yex.Text.insert(text, 5, " World")
+      {:ok, update_b} = Yex.encode_state_as_update(doc1, sv_a)
+
+      doc2 = Yex.Doc.new()
+      :ok = Yex.apply_update(doc2, update_b)
+
+      {:ok, pending} = Yex.get_pending_update(doc2)
+      # The pending binary must itself be a parseable v1 update
+      assert {:ok, debug} = Yex.update_debug_v1(pending)
+      assert is_binary(debug)
+    end
+
+    test "pending update resolves to the same final state regardless of application order" do
+      doc1 = Yex.Doc.new()
+      text = Yex.Doc.get_text(doc1, "text")
+      {:ok, sv_empty} = Yex.encode_state_vector(doc1)
+      Yex.Text.insert(text, 0, "Hello")
+      {:ok, update_a} = Yex.encode_state_as_update(doc1, sv_empty)
+      {:ok, sv_a} = Yex.encode_state_vector(doc1)
+      Yex.Text.insert(text, 5, " World")
+      {:ok, update_b} = Yex.encode_state_as_update(doc1, sv_a)
+
+      # doc2: correct order
+      doc2 = Yex.Doc.new()
+      :ok = Yex.apply_update(doc2, update_a)
+      :ok = Yex.apply_update(doc2, update_b)
+
+      # doc3: reversed order (b first → pending, then a resolves it)
+      doc3 = Yex.Doc.new()
+      :ok = Yex.apply_update(doc3, update_b)
+      :ok = Yex.apply_update(doc3, update_a)
+
+      text2 = Yex.Doc.get_text(doc2, "text")
+      text3 = Yex.Doc.get_text(doc3, "text")
+      assert Yex.Text.to_string(text2) == Yex.Text.to_string(text3)
+      assert Yex.Text.to_string(text3) == "Hello World"
+    end
+
+    test "pending delete set appears when a deletion refers to unknown items" do
+      doc1 = Yex.Doc.new()
+      text = Yex.Doc.get_text(doc1, "text")
+      {:ok, sv_empty} = Yex.encode_state_vector(doc1)
+      Yex.Text.insert(text, 0, "Hello")
+      {:ok, update_insert} = Yex.encode_state_as_update(doc1, sv_empty)
+      {:ok, sv_after_insert} = Yex.encode_state_vector(doc1)
+      Yex.Text.delete(text, 0, 5)
+      {:ok, update_delete} = Yex.encode_state_as_update(doc1, sv_after_insert)
+
+      # doc2 gets the delete before the insert → pending delete set
+      doc2 = Yex.Doc.new()
+      :ok = Yex.apply_update(doc2, update_delete)
+
+      assert {:ok, pending_ds} = Yex.get_pending_ds(doc2)
+      assert is_binary(pending_ds)
+      assert byte_size(pending_ds) > 0
+
+      # Applying the insert resolves both the pending update and delete set
+      :ok = Yex.apply_update(doc2, update_insert)
+      assert {:ok, nil} = Yex.get_pending_ds(doc2)
+    end
+  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added APIs to retrieve a document’s pending updates and pending delete sets in v1-encoded format.
  * Results indicate when no pending data is available and support error handling.

* **Tests**
  * Added coverage for synchronization states, out-of-order updates, update validity, convergence, and pending delete resolution.

* **Benchmarks**
  * Added performance comparisons for applying updates across different document sizes and data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->